### PR TITLE
new route "menu" that is accessible on mobile only

### DIFF
--- a/web/handlers/admin/app_test.go
+++ b/web/handlers/admin/app_test.go
@@ -60,7 +60,7 @@ func newSession(t *testing.T) *testSession {
 
 	r, err := render.New(web.Templates,
 		render.SetLogger(log),
-		render.BaseTemplates("base.tmpl"),
+		render.BaseTemplates("base.tmpl", "menu.tmpl"),
 		render.AddTemplates(append(HTMLTemplates, "error.tmpl")...),
 		render.ErrorTemplate("error.tmpl"),
 		render.FuncMap(testFuncs),

--- a/web/handlers/admin/handler.go
+++ b/web/handlers/admin/handler.go
@@ -16,6 +16,7 @@ import (
 
 var HTMLTemplates = []string{
 	"admin/dashboard.tmpl",
+	"admin/menu.tmpl",
 	"admin/allow-list.tmpl",
 	"admin/allow-list-remove-confirm.tmpl",
 }
@@ -31,6 +32,9 @@ func Handler(r *render.Renderer, roomState *roomstate.Manager, al admindb.AllowL
 			Clients []string
 			Count   int
 		}{lst, len(lst)}, nil
+	}))
+	mux.HandleFunc("/menu", r.HTML("admin/menu.tmpl", func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+		return map[string]interface{}{}, nil
 	}))
 
 	var ah = allowListH{

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -45,7 +45,7 @@ func New(
 
 	r, err := render.New(web.Templates,
 		render.SetLogger(logger),
-		render.BaseTemplates("base.tmpl"),
+		render.BaseTemplates("base.tmpl", "menu.tmpl"),
 		render.AddTemplates(concatTemplates(
 			[]string{
 				"landing/index.tmpl",

--- a/web/handlers/news/app_test.go
+++ b/web/handlers/news/app_test.go
@@ -37,7 +37,7 @@ func newSession(t *testing.T) *testSession {
 	log, _ := logtest.KitLogger("feed", t)
 	r, err := render.New(web.Templates,
 		render.SetLogger(log),
-		render.BaseTemplates("base.tmpl"),
+		render.BaseTemplates("base.tmpl", "menu.tmpl"),
 		render.AddTemplates(append(HTMLTemplates, "error.tmpl")...),
 		render.ErrorTemplate("error.tmpl"),
 		render.FuncMap(testFuncs),

--- a/web/router/admin.go
+++ b/web/router/admin.go
@@ -7,6 +7,7 @@ import "github.com/gorilla/mux"
 // constant names for the named routes
 const (
 	AdminDashboard = "admin:dashboard"
+	AdminMenu      = "admin:menu"
 
 	AdminAllowListOverview      = "admin:allow-list:overview"
 	AdminAllowListAdd           = "admin:allow-list:add"
@@ -21,6 +22,7 @@ func Admin(m *mux.Router) *mux.Router {
 	}
 
 	m.Path("/dashboard").Methods("GET").Name(AdminDashboard)
+	m.Path("/menu").Methods("GET").Name(AdminMenu)
 
 	m.Path("/members").Methods("GET").Name(AdminAllowListOverview)
 	m.Path("/members/add").Methods("POST").Name(AdminAllowListAdd)

--- a/web/templates/admin/menu.tmpl
+++ b/web/templates/admin/menu.tmpl
@@ -1,0 +1,5 @@
+{{ define "title" }}Menu{{ end }}
+{{ define "main"}}<span></span>{{end}}
+{{ define "extra" }}
+  {{template "menu" .}}
+{{end}}

--- a/web/templates/base.tmpl
+++ b/web/templates/base.tmpl
@@ -9,12 +9,17 @@
   <title>{{block "title" .}}Go-SSB Room Server{{end}}</title>
 </head>
 <body class="bg-gray-100">
-  {{block "extra" .}}{{end}}
-
   <div class="sm:mx-auto sm:container">
-    {{$user := is_logged_in}}
-    <div class="flex flex-row justify-end space-x-4 mt-4 sm:my-4">
+    <div class="flex flex-row justify-end space-x-4 my-4">
+      {{$user := is_logged_in}}
       {{if $user}}
+      <div class="ml-4 flex-1 sm:hidden flex flex-row items-center">
+        <a href="{{urlTo "admin:menu"}}">
+          <svg class="w-6 h-6 text-gray-700" viewBox="0 0 24 24">
+            <path fill="currentColor" d="M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z" />
+          </svg>
+        </a>
+      </div>
       <span class="flex flex-row items-center divide-x divide-gray-300">
         <div class="flex flex-row items-center pr-3">
           <svg class="text-green-500 w-4 h-4 mr-1" viewBox="0 0 24 24">
@@ -24,54 +29,33 @@
         </div>
         <a
           href="{{urlTo "auth:fallback:logout"}}"
-          class="pl-3 pr-4 py-3 sm:py-1 font-semibold text-sm text-gray-500 hover:text-red-600"
+          class="pl-3 pr-4 py-2 sm:py-1 font-semibold text-sm text-gray-500 hover:text-red-600"
         >{{i18n "AuthSignOut"}}</a>
       </span>
       {{else}}
       <a
         href="{{urlTo "auth:fallback:signin:form"}}"
-        class="pl-3 pr-4 py-3 sm:py-1 font-semibold text-sm text-gray-500 hover:text-green-600"
+        class="pl-3 pr-4 py-2 sm:py-1 font-semibold text-sm text-gray-500 hover:text-green-600"
       >{{i18n "AuthSignIn"}}</a>
       {{end}}
     </div>
 
-    <div class="flex flex-col sm:flex-row items-start">
+    {{block "extra" .}}{{end}}
+
+    {{block "main" .}}
+    <div class="flex flex-row items-start">
+      {{$user := is_logged_in}}
       {{if $user}}
-      <div class="flex flex-col my-4 w-40 px-2 sm:pl-0">
-        <a
-          href="{{urlTo "news:overview"}}"
-          class="{{if current_page_is "news:overview"}}bg-gray-300 {{else}}hover:bg-gray-200 {{end}}pr-1 pl-2 py-3 sm:py-1 rounded-md flex flex-row items-center font-semibold text-sm text-gray-700 hover:text-gray-800 truncate"
-        >
-          <svg class="text-pink-700 w-4 h-4 mr-1" viewBox="0 0 24 24">
-            <path fill="currentColor" d="M20 5L20 19L4 19L4 5H20M20 3H4C2.89 3 2 3.89 2 5V19C2 20.11 2.89 21 4 21H20C21.11 21 22 20.11 22 19V5C22 3.89 21.11 3 20 3M18 15H6V17H18V15M10 7H6V13H10V7M12 9H18V7H12V9M18 11H12V13H18V11Z" />
-          </svg>‍{{i18n "NewsTitle"}}
-        </a>
-
-        <a
-          href="{{urlTo "admin:dashboard"}}"
-          class="{{if current_page_is "admin:dashboard"}}bg-gray-300 {{else}}hover:bg-gray-200 {{end}}pr-1 pl-2 py-3 sm:py-1 rounded-md flex flex-row items-center font-semibold text-sm text-gray-700 hover:text-gray-800 truncate"
-        >
-          <svg class="text-blue-700 w-4 h-4 mr-1" viewBox="0 0 24 24">
-            <path fill="currentColor" d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,4A8,8 0 0,1 20,12C20,14.4 19,16.5 17.3,18C15.9,16.7 14,16 12,16C10,16 8.2,16.7 6.7,18C5,16.5 4,14.4 4,12A8,8 0 0,1 12,4M14,5.89C13.62,5.9 13.26,6.15 13.1,6.54L11.81,9.77L11.71,10C11,10.13 10.41,10.6 10.14,11.26C9.73,12.29 10.23,13.45 11.26,13.86C12.29,14.27 13.45,13.77 13.86,12.74C14.12,12.08 14,11.32 13.57,10.76L13.67,10.5L14.96,7.29L14.97,7.26C15.17,6.75 14.92,6.17 14.41,5.96C14.28,5.91 14.15,5.89 14,5.89M10,6A1,1 0 0,0 9,7A1,1 0 0,0 10,8A1,1 0 0,0 11,7A1,1 0 0,0 10,6M7,9A1,1 0 0,0 6,10A1,1 0 0,0 7,11A1,1 0 0,0 8,10A1,1 0 0,0 7,9M17,9A1,1 0 0,0 16,10A1,1 0 0,0 17,11A1,1 0 0,0 18,10A1,1 0 0,0 17,9Z" />
-          </svg>{{i18n "NavAdminDashboard"}}
-        </a>
-
-        <a
-          href="{{urlTo "admin:allow-list:overview"}}"
-          class="{{if current_page_is "admin:allow-list:overview"}}bg-gray-300 {{else}}hover:bg-gray-200 {{end}}pr-1 pl-2 py-3 sm:py-1 rounded-md flex flex-row items-center font-semibold text-sm text-gray-700 hover:text-gray-800 truncate"
-        >
-          <svg class="text-purple-700 w-4 h-4 mr-1" viewBox="0 0 24 24">
-            <path fill="currentColor" d="M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,6A2,2 0 0,0 10,8A2,2 0 0,0 12,10A2,2 0 0,0 14,8A2,2 0 0,0 12,6M12,13C14.67,13 20,14.33 20,17V20H4V17C4,14.33 9.33,13 12,13M12,14.9C9.03,14.9 5.9,16.36 5.9,17V18.1H18.1V17C18.1,16.36 14.97,14.9 12,14.9Z" />
-          </svg>{{i18n "AdminAllowListTitle"}}
-        </a>
-      </div>
-      {{else}}
+        <div class="hidden sm:block">
+          {{template "menu" .}}
+        </div>
       {{end}}
 
       <div class="bg-gray-50 rounded-2xl py-4 px-4 sm:px-8 shadow-xl mb-16 flex-1 max-w-full">
         {{ block "content" . }}{{end}}
       </div>
     </div>
+    {{end}}
   </div>
 </body>
 </html>

--- a/web/templates/menu.tmpl
+++ b/web/templates/menu.tmpl
@@ -1,0 +1,30 @@
+{{ define "menu" }}
+<div class="flex flex-col my-4 w-40 px-2 sm:pl-0">
+  <a
+    href="{{urlTo "news:overview"}}"
+    class="{{if current_page_is "news:overview"}}bg-gray-300 {{else}}hover:bg-gray-200 {{end}}pr-1 pl-2 py-3 sm:py-1 rounded-md flex flex-row items-center font-semibold text-sm text-gray-700 hover:text-gray-800 truncate"
+  >
+    <svg class="text-pink-700 w-4 h-4 mr-1" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M20 5L20 19L4 19L4 5H20M20 3H4C2.89 3 2 3.89 2 5V19C2 20.11 2.89 21 4 21H20C21.11 21 22 20.11 22 19V5C22 3.89 21.11 3 20 3M18 15H6V17H18V15M10 7H6V13H10V7M12 9H18V7H12V9M18 11H12V13H18V11Z" />
+    </svg>‍{{i18n "NewsTitle"}}
+  </a>
+
+  <a
+    href="{{urlTo "admin:dashboard"}}"
+    class="{{if current_page_is "admin:dashboard"}}bg-gray-300 {{else}}hover:bg-gray-200 {{end}}pr-1 pl-2 py-3 sm:py-1 rounded-md flex flex-row items-center font-semibold text-sm text-gray-700 hover:text-gray-800 truncate"
+  >
+    <svg class="text-blue-700 w-4 h-4 mr-1" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,4A8,8 0 0,1 20,12C20,14.4 19,16.5 17.3,18C15.9,16.7 14,16 12,16C10,16 8.2,16.7 6.7,18C5,16.5 4,14.4 4,12A8,8 0 0,1 12,4M14,5.89C13.62,5.9 13.26,6.15 13.1,6.54L11.81,9.77L11.71,10C11,10.13 10.41,10.6 10.14,11.26C9.73,12.29 10.23,13.45 11.26,13.86C12.29,14.27 13.45,13.77 13.86,12.74C14.12,12.08 14,11.32 13.57,10.76L13.67,10.5L14.96,7.29L14.97,7.26C15.17,6.75 14.92,6.17 14.41,5.96C14.28,5.91 14.15,5.89 14,5.89M10,6A1,1 0 0,0 9,7A1,1 0 0,0 10,8A1,1 0 0,0 11,7A1,1 0 0,0 10,6M7,9A1,1 0 0,0 6,10A1,1 0 0,0 7,11A1,1 0 0,0 8,10A1,1 0 0,0 7,9M17,9A1,1 0 0,0 16,10A1,1 0 0,0 17,11A1,1 0 0,0 18,10A1,1 0 0,0 17,9Z" />
+    </svg>{{i18n "NavAdminDashboard"}}
+  </a>
+
+  <a
+    href="{{urlTo "admin:allow-list:overview"}}"
+    class="{{if current_page_is "admin:allow-list:overview"}}bg-gray-300 {{else}}hover:bg-gray-200 {{end}}pr-1 pl-2 py-3 sm:py-1 rounded-md flex flex-row items-center font-semibold text-sm text-gray-700 hover:text-gray-800 truncate"
+  >
+    <svg class="text-purple-700 w-4 h-4 mr-1" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,6A2,2 0 0,0 10,8A2,2 0 0,0 12,10A2,2 0 0,0 14,8A2,2 0 0,0 12,6M12,13C14.67,13 20,14.33 20,17V20H4V17C4,14.33 9.33,13 12,13M12,14.9C9.03,14.9 5.9,16.36 5.9,17V18.1H18.1V17C18.1,16.36 14.97,14.9 12,14.9Z" />
+    </svg>{{i18n "AdminAllowListTitle"}}
+  </a>
+</div>
+{{end}}


### PR DESCRIPTION
I found a neat solution to #34:

- When the layout is mobile-or-narrow, don't show the menu at all, instead show a menu icon on the top-left corner
- When the layout is wide, show the menu items and don't show the menu icon
- The menu icon takes you to `/admin/menu` which contains only the menu items

### Desktop looks like

![Screenshot from 2021-02-23 20-20-31](https://user-images.githubusercontent.com/90512/108889449-109c4680-7615-11eb-9dc5-28cc043f1bdd.png)

### Mobile looks like

![Screen Shot 2021-02-23 at 20 20 24](https://user-images.githubusercontent.com/90512/108889474-172abe00-7615-11eb-8a52-9f091d819581.png)

### `/admin/menu` looks like

![Screen Shot 2021-02-23 at 20 20 40](https://user-images.githubusercontent.com/90512/108889491-1db93580-7615-11eb-97fc-ad0bd9581d02.png)
