### PR TITLE
Invite pages

### DIFF
--- a/admindb/interface.go
+++ b/admindb/interface.go
@@ -57,15 +57,21 @@ type AliasService interface{}
 
 // InviteService manages creation and consumption of invite tokens for joining the room.
 type InviteService interface {
-
 	// Create creates a new invite for a new member. It returns the token or an error.
 	// createdBy is user ID of the admin or moderator who created it.
 	// aliasSuggestion is optional (empty string is fine) but can be used to disambiguate open invites. (See https://github.com/ssb-ngi-pointer/rooms2/issues/21)
 	Create(ctx context.Context, createdBy int64, aliasSuggestion string) (string, error)
 
-	// Consume checks if the passed token is still valid. If it is it adds newMember to the members of the room and invalidates the token.
+	// Consume checks if the passed token is still valid.
+	// If it is it adds newMember to the members of the room and invalidates the token.
 	// If the token isn't valid, it returns an error.
 	Consume(ctx context.Context, token string, newMember refs.FeedRef) (Invite, error)
+
+	// GetByToken returns the Invite if one for that token exists, or an error
+	GetByToken(ctx context.Context, token string) (Invite, error)
+
+	// GetByToken returns the Invite if one for that ID exists, or an error
+	GetByID(ctx context.Context, id int64) (Invite, error)
 
 	// List returns a list of all the valid invites
 	List(ctx context.Context) ([]Invite, error)

--- a/admindb/mockdb/invite.go
+++ b/admindb/mockdb/invite.go
@@ -40,6 +40,34 @@ type FakeInviteService struct {
 		result1 string
 		result2 error
 	}
+	GetByIDStub        func(context.Context, int64) (admindb.Invite, error)
+	getByIDMutex       sync.RWMutex
+	getByIDArgsForCall []struct {
+		arg1 context.Context
+		arg2 int64
+	}
+	getByIDReturns struct {
+		result1 admindb.Invite
+		result2 error
+	}
+	getByIDReturnsOnCall map[int]struct {
+		result1 admindb.Invite
+		result2 error
+	}
+	GetByTokenStub        func(context.Context, string) (admindb.Invite, error)
+	getByTokenMutex       sync.RWMutex
+	getByTokenArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	getByTokenReturns struct {
+		result1 admindb.Invite
+		result2 error
+	}
+	getByTokenReturnsOnCall map[int]struct {
+		result1 admindb.Invite
+		result2 error
+	}
 	ListStub        func(context.Context) ([]admindb.Invite, error)
 	listMutex       sync.RWMutex
 	listArgsForCall []struct {
@@ -201,6 +229,136 @@ func (fake *FakeInviteService) CreateReturnsOnCall(i int, result1 string, result
 	}{result1, result2}
 }
 
+func (fake *FakeInviteService) GetByID(arg1 context.Context, arg2 int64) (admindb.Invite, error) {
+	fake.getByIDMutex.Lock()
+	ret, specificReturn := fake.getByIDReturnsOnCall[len(fake.getByIDArgsForCall)]
+	fake.getByIDArgsForCall = append(fake.getByIDArgsForCall, struct {
+		arg1 context.Context
+		arg2 int64
+	}{arg1, arg2})
+	stub := fake.GetByIDStub
+	fakeReturns := fake.getByIDReturns
+	fake.recordInvocation("GetByID", []interface{}{arg1, arg2})
+	fake.getByIDMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeInviteService) GetByIDCallCount() int {
+	fake.getByIDMutex.RLock()
+	defer fake.getByIDMutex.RUnlock()
+	return len(fake.getByIDArgsForCall)
+}
+
+func (fake *FakeInviteService) GetByIDCalls(stub func(context.Context, int64) (admindb.Invite, error)) {
+	fake.getByIDMutex.Lock()
+	defer fake.getByIDMutex.Unlock()
+	fake.GetByIDStub = stub
+}
+
+func (fake *FakeInviteService) GetByIDArgsForCall(i int) (context.Context, int64) {
+	fake.getByIDMutex.RLock()
+	defer fake.getByIDMutex.RUnlock()
+	argsForCall := fake.getByIDArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeInviteService) GetByIDReturns(result1 admindb.Invite, result2 error) {
+	fake.getByIDMutex.Lock()
+	defer fake.getByIDMutex.Unlock()
+	fake.GetByIDStub = nil
+	fake.getByIDReturns = struct {
+		result1 admindb.Invite
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeInviteService) GetByIDReturnsOnCall(i int, result1 admindb.Invite, result2 error) {
+	fake.getByIDMutex.Lock()
+	defer fake.getByIDMutex.Unlock()
+	fake.GetByIDStub = nil
+	if fake.getByIDReturnsOnCall == nil {
+		fake.getByIDReturnsOnCall = make(map[int]struct {
+			result1 admindb.Invite
+			result2 error
+		})
+	}
+	fake.getByIDReturnsOnCall[i] = struct {
+		result1 admindb.Invite
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeInviteService) GetByToken(arg1 context.Context, arg2 string) (admindb.Invite, error) {
+	fake.getByTokenMutex.Lock()
+	ret, specificReturn := fake.getByTokenReturnsOnCall[len(fake.getByTokenArgsForCall)]
+	fake.getByTokenArgsForCall = append(fake.getByTokenArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetByTokenStub
+	fakeReturns := fake.getByTokenReturns
+	fake.recordInvocation("GetByToken", []interface{}{arg1, arg2})
+	fake.getByTokenMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeInviteService) GetByTokenCallCount() int {
+	fake.getByTokenMutex.RLock()
+	defer fake.getByTokenMutex.RUnlock()
+	return len(fake.getByTokenArgsForCall)
+}
+
+func (fake *FakeInviteService) GetByTokenCalls(stub func(context.Context, string) (admindb.Invite, error)) {
+	fake.getByTokenMutex.Lock()
+	defer fake.getByTokenMutex.Unlock()
+	fake.GetByTokenStub = stub
+}
+
+func (fake *FakeInviteService) GetByTokenArgsForCall(i int) (context.Context, string) {
+	fake.getByTokenMutex.RLock()
+	defer fake.getByTokenMutex.RUnlock()
+	argsForCall := fake.getByTokenArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeInviteService) GetByTokenReturns(result1 admindb.Invite, result2 error) {
+	fake.getByTokenMutex.Lock()
+	defer fake.getByTokenMutex.Unlock()
+	fake.GetByTokenStub = nil
+	fake.getByTokenReturns = struct {
+		result1 admindb.Invite
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeInviteService) GetByTokenReturnsOnCall(i int, result1 admindb.Invite, result2 error) {
+	fake.getByTokenMutex.Lock()
+	defer fake.getByTokenMutex.Unlock()
+	fake.GetByTokenStub = nil
+	if fake.getByTokenReturnsOnCall == nil {
+		fake.getByTokenReturnsOnCall = make(map[int]struct {
+			result1 admindb.Invite
+			result2 error
+		})
+	}
+	fake.getByTokenReturnsOnCall[i] = struct {
+		result1 admindb.Invite
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeInviteService) List(arg1 context.Context) ([]admindb.Invite, error) {
 	fake.listMutex.Lock()
 	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
@@ -334,6 +492,10 @@ func (fake *FakeInviteService) Invocations() map[string][][]interface{} {
 	defer fake.consumeMutex.RUnlock()
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
+	fake.getByIDMutex.RLock()
+	defer fake.getByIDMutex.RUnlock()
+	fake.getByTokenMutex.RLock()
+	defer fake.getByTokenMutex.RUnlock()
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
 	fake.revokeMutex.RLock()

--- a/admindb/sqlite/invites.go
+++ b/admindb/sqlite/invites.go
@@ -155,6 +155,9 @@ func (i Invites) GetByToken(ctx context.Context, token string) (admindb.Invite, 
 		qm.Load("CreatedByAuthFallback"),
 	).One(ctx, i.db)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return inv, admindb.ErrNotFound
+		}
 		return inv, err
 	}
 
@@ -174,6 +177,9 @@ func (i Invites) GetByID(ctx context.Context, id int64) (admindb.Invite, error) 
 		qm.Load("CreatedByAuthFallback"),
 	).One(ctx, i.db)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return inv, admindb.ErrNotFound
+		}
 		return inv, err
 	}
 
@@ -225,6 +231,9 @@ func (i Invites) Revoke(ctx context.Context, id int64) error {
 			qm.Where("active = true AND id = ?", id),
 		).One(ctx, tx)
 		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return admindb.ErrNotFound
+			}
 			return err
 		}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -215,12 +215,14 @@ func runroomsrv() error {
 		repo.New(repoDir),
 		httpsDomain,
 		roomsrv.StateManager,
-		db.AuthWithSSB,
-		db.AuthFallback,
-		db.AllowList,
-		db.Invites,
-		db.Notices,
-		db.PinnedNotices,
+		handlers.Databases{
+			AuthWithSSB:   db.AuthWithSSB,
+			AuthFallback:  db.AuthFallback,
+			AllowList:     db.AllowList,
+			Invites:       db.Invites,
+			Notices:       db.Notices,
+			PinnedNotices: db.PinnedNotices,
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTPdashboard handler: %w", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -213,6 +213,7 @@ func runroomsrv() error {
 	dashboardH, err := handlers.New(
 		kitlog.With(log, "package", "web"),
 		repo.New(repoDir),
+		httpsDomain,
 		roomsrv.StateManager,
 		db.AuthWithSSB,
 		db.AuthFallback,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -127,12 +127,33 @@ func runroomsrv() error {
 		return fmt.Errorf("https-domain can't be empty. See '%s -h' for a full list of options", os.Args[0])
 	}
 
+	// validate listen addresses to bail out on invalid flag input before doing anything else
+	_, muxrpcPortStr, err := net.SplitHostPort(listenAddrShsMux)
+	if err != nil {
+		return fmt.Errorf("invalid muxrpc listener: %w", err)
+	}
+
+	portMUXRPC, err := net.LookupPort("tcp", muxrpcPortStr)
+	if err != nil {
+		return fmt.Errorf("invalid tcp port for muxrpc listener: %w", err)
+	}
+
+	_, portHTTPStr, err := net.SplitHostPort(listenAddrHTTP)
+	if err != nil {
+		return fmt.Errorf("invalid http listener: %w", err)
+	}
+
+	portHTTP, err := net.LookupPort("tcp", portHTTPStr)
+	if err != nil {
+		return fmt.Errorf("invalid tcp port for muxrpc listener: %w", err)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	ak, err := base64.StdEncoding.DecodeString(appKey)
 	if err != nil {
-		return fmt.Errorf("application key: %w", err)
+		return fmt.Errorf("secret-handshake appkey is invalid base64: %w", err)
 	}
 
 	opts := []roomsrv.Option{
@@ -213,7 +234,12 @@ func runroomsrv() error {
 	dashboardH, err := handlers.New(
 		kitlog.With(log, "package", "web"),
 		repo.New(repoDir),
-		httpsDomain,
+		handlers.NetworkInfo{
+			Domain:     httpsDomain,
+			PortHTTPS:  uint(portHTTP),
+			PortMUXRPC: uint(portMUXRPC),
+			PubKey:     roomsrv.Whoami().PubKey(),
+		},
 		roomsrv.StateManager,
 		handlers.Databases{
 			AuthWithSSB:   db.AuthWithSSB,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -217,6 +217,7 @@ func runroomsrv() error {
 		db.AuthWithSSB,
 		db.AuthFallback,
 		db.AllowList,
+		db.Invites,
 		db.Notices,
 		db.PinnedNotices,
 	)

--- a/web/handlers/admin/allow_list.go
+++ b/web/handlers/admin/allow_list.go
@@ -20,7 +20,7 @@ type allowListH struct {
 	al admindb.AllowListService
 }
 
-const redirectTo = "/admin/members"
+const redirectToMembers = "/admin/members"
 
 func (h allowListH) add(w http.ResponseWriter, req *http.Request) {
 	if req.Method != "POST" {
@@ -57,7 +57,7 @@ func (h allowListH) add(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	http.Redirect(w, req, redirectTo, http.StatusFound)
+	http.Redirect(w, req, redirectToMembers, http.StatusFound)
 }
 
 func (h allowListH) overview(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -93,7 +93,7 @@ func (h allowListH) removeConfirm(rw http.ResponseWriter, req *http.Request) (in
 	entry, err := h.al.GetByID(req.Context(), id)
 	if err != nil {
 		if errors.Is(err, admindb.ErrNotFound) {
-			http.Redirect(rw, req, redirectTo, http.StatusFound)
+			http.Redirect(rw, req, redirectToMembers, http.StatusFound)
 			return nil, ErrRedirected
 		}
 		return nil, err
@@ -109,7 +109,7 @@ func (h allowListH) remove(rw http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		err = weberrors.ErrBadRequest{Where: "Form data", Details: err}
 		// TODO "flash" errors
-		http.Redirect(rw, req, redirectTo, http.StatusFound)
+		http.Redirect(rw, req, redirectToMembers, http.StatusFound)
 		return
 	}
 
@@ -117,7 +117,7 @@ func (h allowListH) remove(rw http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		err = weberrors.ErrBadRequest{Where: "ID", Details: err}
 		// TODO "flash" errors
-		http.Redirect(rw, req, redirectTo, http.StatusFound)
+		http.Redirect(rw, req, redirectToMembers, http.StatusFound)
 		return
 	}
 
@@ -132,5 +132,5 @@ func (h allowListH) remove(rw http.ResponseWriter, req *http.Request) {
 		status = http.StatusNotFound
 	}
 
-	http.Redirect(rw, req, redirectTo, status)
+	http.Redirect(rw, req, redirectToMembers, status)
 }

--- a/web/handlers/admin/allow_list.go
+++ b/web/handlers/admin/allow_list.go
@@ -14,7 +14,7 @@ import (
 	weberrors "github.com/ssb-ngi-pointer/go-ssb-room/web/errors"
 )
 
-type allowListH struct {
+type allowListHandler struct {
 	r *render.Renderer
 
 	al admindb.AllowListService
@@ -22,7 +22,7 @@ type allowListH struct {
 
 const redirectToMembers = "/admin/members"
 
-func (h allowListH) add(w http.ResponseWriter, req *http.Request) {
+func (h allowListHandler) add(w http.ResponseWriter, req *http.Request) {
 	if req.Method != "POST" {
 		// TODO: proper error type
 		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request"))
@@ -60,7 +60,7 @@ func (h allowListH) add(w http.ResponseWriter, req *http.Request) {
 	http.Redirect(w, req, redirectToMembers, http.StatusFound)
 }
 
-func (h allowListH) overview(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (h allowListHandler) overview(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
 	lst, err := h.al.List(req.Context())
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func (h allowListH) overview(rw http.ResponseWriter, req *http.Request) (interfa
 // TODO: move to render package so that we can decide to not render a page during the controller
 var ErrRedirected = errors.New("render: not rendered but redirected")
 
-func (h allowListH) removeConfirm(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (h allowListHandler) removeConfirm(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
 	id, err := strconv.ParseInt(req.URL.Query().Get("id"), 10, 64)
 	if err != nil {
 		err = weberrors.ErrBadRequest{Where: "ID", Details: err}
@@ -104,7 +104,7 @@ func (h allowListH) removeConfirm(rw http.ResponseWriter, req *http.Request) (in
 	}, nil
 }
 
-func (h allowListH) remove(rw http.ResponseWriter, req *http.Request) {
+func (h allowListHandler) remove(rw http.ResponseWriter, req *http.Request) {
 	err := req.ParseForm()
 	if err != nil {
 		err = weberrors.ErrBadRequest{Where: "Form data", Details: err}

--- a/web/handlers/admin/allow_list.go
+++ b/web/handlers/admin/allow_list.go
@@ -76,6 +76,8 @@ func (h allowListH) overview(rw http.ResponseWriter, req *http.Request) (interfa
 	}
 	count := len(lst)
 
+	// TODO: generalize paginator code
+
 	num, err := strconv.ParseInt(req.URL.Query().Get("page"), 10, 32)
 	if err != nil {
 		num = 1

--- a/web/handlers/admin/allow_list.go
+++ b/web/handlers/admin/allow_list.go
@@ -98,6 +98,7 @@ func (h allowListHandler) removeConfirm(rw http.ResponseWriter, req *http.Reques
 		}
 		return nil, err
 	}
+
 	return map[string]interface{}{
 		"Entry":          entry,
 		csrf.TemplateTag: csrf.TemplateField(req),

--- a/web/handlers/admin/allow_list_test.go
+++ b/web/handlers/admin/allow_list_test.go
@@ -64,6 +64,7 @@ func TestAllowListAdd(t *testing.T) {
 	a.EqualValues(1, inputSelection.Length())
 
 	name, ok := inputSelection.Attr("name")
+	a.True(ok, "field has a name")
 	a.Equal("pub_key", name, "wrong name on input field")
 
 	newKey := "@x7iOLUcq3o+sjGeAnipvWeGzfuYgrXl8L4LYlxIhwDc=.ed25519"

--- a/web/handlers/admin/allow_list_test.go
+++ b/web/handlers/admin/allow_list_test.go
@@ -149,7 +149,7 @@ func TestAllowList(t *testing.T) {
 	// check for link to remove confirm link
 	link, yes := elems.ContentsFiltered("a").Attr("href")
 	a.True(yes, "a-tag has href attribute")
-	a.Equal("/members/remove/confirm?id=666", link)
+	a.Equal("/admin/members/remove/confirm?id=666", link)
 }
 
 func TestAllowListRemoveConfirmation(t *testing.T) {

--- a/web/handlers/admin/app_test.go
+++ b/web/handlers/admin/app_test.go
@@ -4,6 +4,7 @@ package admin
 
 import (
 	"context"
+	"math/rand"
 	"net/http"
 	"testing"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/ssb-ngi-pointer/go-ssb-room/roomstate"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/user"
 )
 
 type testSession struct {
@@ -29,6 +31,10 @@ type testSession struct {
 	PinnedDB    *mockdb.FakePinnedNoticesService
 	NoticeDB    *mockdb.FakeNoticesService
 	InvitesDB   *mockdb.FakeInviteService
+
+	User *admindb.User
+
+	Domain string
 
 	RoomState *roomstate.Manager
 }
@@ -46,7 +52,15 @@ func newSession(t *testing.T) *testSession {
 	ctx := context.TODO()
 	ts.RoomState = roomstate.NewManager(ctx, log)
 
-	ts.Router = router.Admin(nil)
+	ts.Router = router.CompleteApp()
+
+	ts.Domain = randomString(10)
+
+	// fake user
+	ts.User = &admindb.User{
+		ID:   1234,
+		Name: "room mate",
+	}
 
 	// setup rendering
 
@@ -77,14 +91,34 @@ func newSession(t *testing.T) *testSession {
 	}
 
 	ts.Mux = http.NewServeMux()
-	ts.Mux.Handle("/", Handler(r,
+
+	handler := Handler(
+		ts.Domain,
+		r,
 		ts.RoomState,
 		ts.AllowListDB,
 		ts.InvitesDB,
 		ts.NoticeDB,
 		ts.PinnedDB,
-	))
+	)
+
+	handler = user.MiddlewareForTests(ts.User)(handler)
+
+	ts.Mux.Handle("/", handler)
+
 	ts.Client = tester.New(ts.Mux, t)
 
 	return &ts
+}
+
+// utils
+
+func randomString(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(s)
 }

--- a/web/handlers/admin/app_test.go
+++ b/web/handlers/admin/app_test.go
@@ -28,6 +28,7 @@ type testSession struct {
 	AllowListDB *mockdb.FakeAllowListService
 	PinnedDB    *mockdb.FakePinnedNoticesService
 	NoticeDB    *mockdb.FakeNoticesService
+	InvitesDB   *mockdb.FakeInviteService
 
 	RoomState *roomstate.Manager
 }
@@ -39,6 +40,7 @@ func newSession(t *testing.T) *testSession {
 	ts.AllowListDB = new(mockdb.FakeAllowListService)
 	ts.PinnedDB = new(mockdb.FakePinnedNoticesService)
 	ts.NoticeDB = new(mockdb.FakeNoticesService)
+	ts.InvitesDB = new(mockdb.FakeInviteService)
 
 	log, _ := logtest.KitLogger("admin", t)
 	ctx := context.TODO()
@@ -75,7 +77,13 @@ func newSession(t *testing.T) *testSession {
 	}
 
 	ts.Mux = http.NewServeMux()
-	ts.Mux.Handle("/", Handler(r, ts.RoomState, ts.AllowListDB, ts.NoticeDB, ts.PinnedDB))
+	ts.Mux.Handle("/", Handler(r,
+		ts.RoomState,
+		ts.AllowListDB,
+		ts.InvitesDB,
+		ts.NoticeDB,
+		ts.PinnedDB,
+	))
 	ts.Client = tester.New(ts.Mux, t)
 
 	return &ts

--- a/web/handlers/admin/app_test.go
+++ b/web/handlers/admin/app_test.go
@@ -96,10 +96,12 @@ func newSession(t *testing.T) *testSession {
 		ts.Domain,
 		r,
 		ts.RoomState,
-		ts.AllowListDB,
-		ts.InvitesDB,
-		ts.NoticeDB,
-		ts.PinnedDB,
+		Databases{
+			AllowList:     ts.AllowListDB,
+			Invites:       ts.InvitesDB,
+			Notices:       ts.NoticeDB,
+			PinnedNotices: ts.PinnedDB,
+		},
 	)
 
 	handler = user.MiddlewareForTests(ts.User)(handler)

--- a/web/handlers/admin/handler.go
+++ b/web/handlers/admin/handler.go
@@ -9,13 +9,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
 	"github.com/vcraescu/go-paginator/v2"
 	"github.com/vcraescu/go-paginator/v2/adapter"
 	"github.com/vcraescu/go-paginator/v2/view"
-
 	"go.mindeco.de/http/render"
 
+	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
 	"github.com/ssb-ngi-pointer/go-ssb-room/roomstate"
 )
 
@@ -26,7 +25,9 @@ var HTMLTemplates = []string{
 	"admin/allow-list.tmpl",
 	"admin/allow-list-remove-confirm.tmpl",
 
-	"admin/invites.tmpl",
+	"admin/invite-list.tmpl",
+	"admin/invite-revoke-confirm.tmpl",
+	"admin/invite-created.tmpl",
 
 	"admin/notice-edit.tmpl",
 }
@@ -34,6 +35,7 @@ var HTMLTemplates = []string{
 // Handler supplies the elevated access pages to known users.
 // It is not registering on the mux router like other pages to clean up the authorize flow.
 func Handler(
+	domainName string,
 	r *render.Renderer,
 	roomState *roomstate.Manager,
 	al admindb.AllowListService,
@@ -67,9 +69,13 @@ func Handler(
 	var ih = invitesHandler{
 		r:  r,
 		db: is,
+
+		domainName: domainName,
 	}
-	mux.HandleFunc("/invites", r.HTML("admin/invites.tmpl", ih.overview))
-	mux.HandleFunc("/invites/create", ih.create)
+	mux.HandleFunc("/invites", r.HTML("admin/invite-list.tmpl", ih.overview))
+	mux.HandleFunc("/invites/create", r.HTML("admin/invite-created.tmpl", ih.create))
+	mux.HandleFunc("/invites/revoke/confirm", r.HTML("admin/invite-revoke-confirm.tmpl", ih.revokeConfirm))
+	mux.HandleFunc("/invites/revoke", ih.revoke)
 
 	var nh = noticeHandler{
 		r:        r,

--- a/web/handlers/admin/handler.go
+++ b/web/handlers/admin/handler.go
@@ -21,6 +21,8 @@ var HTMLTemplates = []string{
 	"admin/allow-list.tmpl",
 	"admin/allow-list-remove-confirm.tmpl",
 
+	"admin/invites.tmpl",
+
 	"admin/notice-edit.tmpl",
 }
 
@@ -30,6 +32,7 @@ func Handler(
 	r *render.Renderer,
 	roomState *roomstate.Manager,
 	al admindb.AllowListService,
+	is admindb.InviteService,
 	ndb admindb.NoticesService,
 	pdb admindb.PinnedNoticesService,
 ) http.Handler {
@@ -56,6 +59,13 @@ func Handler(
 	mux.HandleFunc("/members/add", ah.add)
 	mux.HandleFunc("/members/remove/confirm", r.HTML("admin/allow-list-remove-confirm.tmpl", ah.removeConfirm))
 	mux.HandleFunc("/members/remove", ah.remove)
+
+	var ih = invitesH{
+		r:  r,
+		db: is,
+	}
+
+	mux.HandleFunc("/invites", r.HTML("admin/invites.tmpl", ih.overview))
 
 	var nh = noticeHandler{
 		r:        r,

--- a/web/handlers/admin/handler.go
+++ b/web/handlers/admin/handler.go
@@ -59,7 +59,6 @@ func Handler(
 		r:  r,
 		al: al,
 	}
-
 	mux.HandleFunc("/members", r.HTML("admin/allow-list.tmpl", ah.overview))
 	mux.HandleFunc("/members/add", ah.add)
 	mux.HandleFunc("/members/remove/confirm", r.HTML("admin/allow-list-remove-confirm.tmpl", ah.removeConfirm))
@@ -69,8 +68,8 @@ func Handler(
 		r:  r,
 		db: is,
 	}
-
 	mux.HandleFunc("/invites", r.HTML("admin/invites.tmpl", ih.overview))
+	mux.HandleFunc("/invites/create", ih.create)
 
 	var nh = noticeHandler{
 		r:        r,

--- a/web/handlers/admin/handler.go
+++ b/web/handlers/admin/handler.go
@@ -55,7 +55,7 @@ func Handler(
 		return map[string]interface{}{}, nil
 	}))
 
-	var ah = allowListH{
+	var ah = allowListHandler{
 		r:  r,
 		al: al,
 	}
@@ -64,7 +64,7 @@ func Handler(
 	mux.HandleFunc("/members/remove/confirm", r.HTML("admin/allow-list-remove-confirm.tmpl", ah.removeConfirm))
 	mux.HandleFunc("/members/remove", ah.remove)
 
-	var ih = invitesH{
+	var ih = invitesHandler{
 		r:  r,
 		db: is,
 	}

--- a/web/handlers/admin/handler.go
+++ b/web/handlers/admin/handler.go
@@ -32,16 +32,21 @@ var HTMLTemplates = []string{
 	"admin/notice-edit.tmpl",
 }
 
+// Databases is an option struct that encapsualtes the required database services
+type Databases struct {
+	AllowList     admindb.AllowListService
+	Invites       admindb.InviteService
+	Notices       admindb.NoticesService
+	PinnedNotices admindb.PinnedNoticesService
+}
+
 // Handler supplies the elevated access pages to known users.
 // It is not registering on the mux router like other pages to clean up the authorize flow.
 func Handler(
 	domainName string,
 	r *render.Renderer,
 	roomState *roomstate.Manager,
-	al admindb.AllowListService,
-	is admindb.InviteService,
-	ndb admindb.NoticesService,
-	pdb admindb.PinnedNoticesService,
+	dbs Databases,
 ) http.Handler {
 	mux := &http.ServeMux{}
 	// TODO: configure 404 handler
@@ -59,7 +64,7 @@ func Handler(
 
 	var ah = allowListHandler{
 		r:  r,
-		al: al,
+		al: dbs.AllowList,
 	}
 	mux.HandleFunc("/members", r.HTML("admin/allow-list.tmpl", ah.overview))
 	mux.HandleFunc("/members/add", ah.add)
@@ -68,7 +73,7 @@ func Handler(
 
 	var ih = invitesHandler{
 		r:  r,
-		db: is,
+		db: dbs.Invites,
 
 		domainName: domainName,
 	}
@@ -79,8 +84,8 @@ func Handler(
 
 	var nh = noticeHandler{
 		r:        r,
-		noticeDB: ndb,
-		pinnedDB: pdb,
+		noticeDB: dbs.Notices,
+		pinnedDB: dbs.PinnedNotices,
 	}
 	mux.HandleFunc("/notice/edit", r.HTML("admin/notice-edit.tmpl", nh.edit))
 	mux.HandleFunc("/notice/translation/draft", r.HTML("admin/notice-edit.tmpl", nh.draftTranslation))

--- a/web/handlers/admin/invites.go
+++ b/web/handlers/admin/invites.go
@@ -1,13 +1,18 @@
 package admin
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
-
-	"go.mindeco.de/http/render"
+	"strconv"
 
 	"github.com/gorilla/csrf"
+	"go.mindeco.de/http/render"
+
 	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web"
+	weberrors "github.com/ssb-ngi-pointer/go-ssb-room/web/errors"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/user"
 )
 
@@ -15,6 +20,8 @@ type invitesHandler struct {
 	r *render.Renderer
 
 	db admindb.InviteService
+
+	domainName string
 }
 
 func (h invitesHandler) overview(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -34,38 +41,106 @@ func (h invitesHandler) overview(rw http.ResponseWriter, req *http.Request) (int
 	}
 
 	pageData[csrf.TemplateTag] = csrf.TemplateField(req)
-
 	return pageData, nil
 }
 
-func (h invitesHandler) create(w http.ResponseWriter, req *http.Request) {
+func (h invitesHandler) create(w http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if req.Method != "POST" {
 		// TODO: proper error type
-		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request"))
-		return
+		return nil, fmt.Errorf("bad request")
 	}
 	if err := req.ParseForm(); err != nil {
 		// TODO: proper error type
-		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request: %w", err))
-		return
+		return nil, fmt.Errorf("bad request: %w", err)
 	}
 
 	user := user.FromContext(req.Context())
 	if user == nil {
-		err := fmt.Errorf("warning: no user session for elevated access request")
-		h.r.Error(w, req, http.StatusInternalServerError, err)
-		return
+		return nil, fmt.Errorf("warning: no user session for elevated access request")
 	}
 
 	aliasSuggestion := req.Form.Get("alias_suggestion")
 
 	token, err := h.db.Create(req.Context(), user.ID, aliasSuggestion)
 	if err != nil {
-		h.r.Error(w, req, http.StatusInternalServerError, err)
+		return nil, err
+	}
+
+	urlTo := web.NewURLTo(router.CompleteApp())
+	acceptURL := urlTo(router.CompleteInviteAccept, "token", token)
+	acceptURL.Host = h.domainName
+	acceptURL.Scheme = "https"
+
+	return map[string]interface{}{
+		"Token":    token,
+		"AccepURL": acceptURL.String(),
+
+		"AliasSuggestion": aliasSuggestion,
+	}, nil
+}
+
+func (h invitesHandler) revokeConfirm(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
+	id, err := strconv.ParseInt(req.URL.Query().Get("id"), 10, 64)
+	if err != nil {
+		err = weberrors.ErrBadRequest{Where: "ID", Details: err}
+		return nil, err
+	}
+
+	// TODO: add GetByID to invite service
+	var invite admindb.Invite
+	list, err := h.db.List(req.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	found := false
+	for _, elem := range list {
+		if elem.ID == id {
+			invite = elem
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, weberrors.ErrNotFound{What: "invite"}
+	}
+
+	return map[string]interface{}{
+		"Invite":         invite,
+		csrf.TemplateTag: csrf.TemplateField(req),
+	}, nil
+}
+
+const redirectToInvites = "/admin/invites"
+
+func (h invitesHandler) revoke(rw http.ResponseWriter, req *http.Request) {
+	err := req.ParseForm()
+	if err != nil {
+		err = weberrors.ErrBadRequest{Where: "Form data", Details: err}
+		// TODO "flash" errors
+		http.Redirect(rw, req, redirectToInvites, http.StatusFound)
 		return
 	}
 
-	fmt.Println("use me:", token)
+	id, err := strconv.ParseInt(req.FormValue("id"), 10, 64)
+	if err != nil {
+		err = weberrors.ErrBadRequest{Where: "ID", Details: err}
+		// TODO "flash" errors
+		http.Redirect(rw, req, redirectToInvites, http.StatusFound)
+		return
+	}
 
-	http.Redirect(w, req, "/admin/invites", http.StatusFound)
+	status := http.StatusFound
+	err = h.db.Revoke(req.Context(), id)
+	if err != nil {
+		if !errors.Is(err, admindb.ErrNotFound) {
+			// TODO "flash" errors
+			h.r.Error(rw, req, http.StatusInternalServerError, err)
+			return
+		}
+		status = http.StatusNotFound
+	}
+
+	http.Redirect(rw, req, redirectToInvites, status)
 }

--- a/web/handlers/admin/invites.go
+++ b/web/handlers/admin/invites.go
@@ -1,0 +1,84 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"go.mindeco.de/http/render"
+
+	"github.com/gorilla/csrf"
+	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
+	"github.com/vcraescu/go-paginator/v2"
+	"github.com/vcraescu/go-paginator/v2/adapter"
+	"github.com/vcraescu/go-paginator/v2/view"
+)
+
+type invitesH struct {
+	r *render.Renderer
+
+	db admindb.InviteService
+}
+
+func (h invitesH) overview(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
+	lst, err := h.db.List(req.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	// Reverse the slice to provide recent-to-oldest results
+	for i, j := 0, len(lst)-1; i < j; i, j = i+1, j-1 {
+		lst[i], lst[j] = lst[j], lst[i]
+	}
+
+	// TODO: generalize paginator code
+
+	count := len(lst)
+
+	num, err := strconv.ParseInt(req.URL.Query().Get("page"), 10, 32)
+	if err != nil {
+		num = 1
+	}
+	page := int(num)
+	if page < 1 {
+		page = 1
+	}
+
+	paginator := paginator.New(adapter.NewSliceAdapter(lst), pageSize)
+	paginator.SetPage(page)
+
+	var entries admindb.ListEntries
+	if err = paginator.Results(&entries); err != nil {
+		return nil, fmt.Errorf("paginator failed with %w", err)
+	}
+
+	view := view.New(paginator)
+	pagesSlice, err := view.Pages()
+	if err != nil {
+		return nil, fmt.Errorf("paginator view.Pages failed with %w", err)
+	}
+	if len(pagesSlice) == 0 {
+		pagesSlice = []int{1}
+	}
+	last, err := view.Last()
+	if err != nil {
+		return nil, fmt.Errorf("paginator view.Last failed with %w", err)
+	}
+	firstInView := pagesSlice[0] == 1
+	lastInView := false
+	for _, num := range pagesSlice {
+		if num == last {
+			lastInView = true
+		}
+	}
+
+	return map[string]interface{}{
+		csrf.TemplateTag: csrf.TemplateField(req),
+		"Entries":        entries,
+		"Count":          count,
+		"Paginator":      paginator,
+		"View":           view,
+		"FirstInView":    firstInView,
+		"LastInView":     lastInView,
+	}, nil
+}

--- a/web/handlers/admin/invites.go
+++ b/web/handlers/admin/invites.go
@@ -11,13 +11,13 @@ import (
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/user"
 )
 
-type invitesH struct {
+type invitesHandler struct {
 	r *render.Renderer
 
 	db admindb.InviteService
 }
 
-func (h invitesH) overview(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (h invitesHandler) overview(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
 	lst, err := h.db.List(req.Context())
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (h invitesH) overview(rw http.ResponseWriter, req *http.Request) (interface
 	return pageData, nil
 }
 
-func (h invitesH) create(w http.ResponseWriter, req *http.Request) {
+func (h invitesHandler) create(w http.ResponseWriter, req *http.Request) {
 	if req.Method != "POST" {
 		// TODO: proper error type
 		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request"))

--- a/web/handlers/admin/invites.go
+++ b/web/handlers/admin/invites.go
@@ -86,24 +86,12 @@ func (h invitesHandler) revokeConfirm(rw http.ResponseWriter, req *http.Request)
 		return nil, err
 	}
 
-	// TODO: add GetByID to invite service
-	var invite admindb.Invite
-	list, err := h.db.List(req.Context())
+	invite, err := h.db.GetByID(req.Context(), id)
 	if err != nil {
-		return nil, err
-	}
-
-	found := false
-	for _, elem := range list {
-		if elem.ID == id {
-			invite = elem
-			found = true
-			break
+		if errors.Is(err, admindb.ErrNotFound) {
+			return nil, weberrors.ErrNotFound{What: "invite"}
 		}
-	}
-
-	if !found {
-		return nil, weberrors.ErrNotFound{What: "invite"}
+		return nil, err
 	}
 
 	return map[string]interface{}{

--- a/web/handlers/admin/invites.go
+++ b/web/handlers/admin/invites.go
@@ -1,12 +1,14 @@
 package admin
 
 import (
+	"fmt"
 	"net/http"
 
 	"go.mindeco.de/http/render"
 
 	"github.com/gorilla/csrf"
 	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/user"
 )
 
 type invitesH struct {
@@ -34,4 +36,30 @@ func (h invitesH) overview(rw http.ResponseWriter, req *http.Request) (interface
 	pageData[csrf.TemplateTag] = csrf.TemplateField(req)
 
 	return pageData, nil
+}
+
+func (h invitesH) create(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "POST" {
+		// TODO: proper error type
+		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request"))
+		return
+	}
+	if err := req.ParseForm(); err != nil {
+		// TODO: proper error type
+		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request: %w", err))
+		return
+	}
+
+
+	aliasSuggestion := req.Form.Get("alias_suggestion")
+
+	token, err := h.db.Create(req.Context(), user.ID, aliasSuggestion)
+	if err != nil {
+		h.r.Error(w, req, http.StatusInternalServerError, err)
+		return
+	}
+
+	fmt.Println("use me:", token)
+
+	http.Redirect(w, req, "/admin/invites", http.StatusFound)
 }

--- a/web/handlers/admin/invites.go
+++ b/web/handlers/admin/invites.go
@@ -1,17 +1,12 @@
 package admin
 
 import (
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"go.mindeco.de/http/render"
 
 	"github.com/gorilla/csrf"
 	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
-	"github.com/vcraescu/go-paginator/v2"
-	"github.com/vcraescu/go-paginator/v2/adapter"
-	"github.com/vcraescu/go-paginator/v2/view"
 )
 
 type invitesH struct {
@@ -31,54 +26,12 @@ func (h invitesH) overview(rw http.ResponseWriter, req *http.Request) (interface
 		lst[i], lst[j] = lst[j], lst[i]
 	}
 
-	// TODO: generalize paginator code
-
-	count := len(lst)
-
-	num, err := strconv.ParseInt(req.URL.Query().Get("page"), 10, 32)
+	pageData, err := paginate(lst, len(lst), req.URL.Query())
 	if err != nil {
-		num = 1
-	}
-	page := int(num)
-	if page < 1 {
-		page = 1
+		return nil, err
 	}
 
-	paginator := paginator.New(adapter.NewSliceAdapter(lst), pageSize)
-	paginator.SetPage(page)
+	pageData[csrf.TemplateTag] = csrf.TemplateField(req)
 
-	var entries admindb.ListEntries
-	if err = paginator.Results(&entries); err != nil {
-		return nil, fmt.Errorf("paginator failed with %w", err)
-	}
-
-	view := view.New(paginator)
-	pagesSlice, err := view.Pages()
-	if err != nil {
-		return nil, fmt.Errorf("paginator view.Pages failed with %w", err)
-	}
-	if len(pagesSlice) == 0 {
-		pagesSlice = []int{1}
-	}
-	last, err := view.Last()
-	if err != nil {
-		return nil, fmt.Errorf("paginator view.Last failed with %w", err)
-	}
-	firstInView := pagesSlice[0] == 1
-	lastInView := false
-	for _, num := range pagesSlice {
-		if num == last {
-			lastInView = true
-		}
-	}
-
-	return map[string]interface{}{
-		csrf.TemplateTag: csrf.TemplateField(req),
-		"Entries":        entries,
-		"Count":          count,
-		"Paginator":      paginator,
-		"View":           view,
-		"FirstInView":    firstInView,
-		"LastInView":     lastInView,
-	}, nil
+	return pageData, nil
 }

--- a/web/handlers/admin/invites.go
+++ b/web/handlers/admin/invites.go
@@ -50,6 +50,12 @@ func (h invitesH) create(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	user := user.FromContext(req.Context())
+	if user == nil {
+		err := fmt.Errorf("warning: no user session for elevated access request")
+		h.r.Error(w, req, http.StatusInternalServerError, err)
+		return
+	}
 
 	aliasSuggestion := req.Form.Get("alias_suggestion")
 

--- a/web/handlers/admin/invites_test.go
+++ b/web/handlers/admin/invites_test.go
@@ -2,10 +2,15 @@ package admin
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 
-	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
+	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ssb-ngi-pointer/go-ssb-room/web"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
 )
 
 func TestInvitesCreateForm(t *testing.T) {
@@ -44,4 +49,40 @@ func TestInvitesCreateForm(t *testing.T) {
 	name, ok := inputSelection.Attr("name")
 	a.True(ok, "input has a name")
 	a.Equal("alias_suggestion", name, "wrong name on input field")
+}
+
+func TestInvitesCreate(t *testing.T) {
+	ts := newSession(t)
+	a := assert.New(t)
+
+	urlTo := web.NewURLTo(ts.Router)
+	urlRemove := urlTo(router.AdminInvitesCreate)
+
+	testInvite := "your-fake-test-invite"
+	ts.InvitesDB.CreateReturns(testInvite, nil)
+
+	rec := ts.Client.PostForm(urlRemove.String(), url.Values{
+		"alias_suggestion": []string{"jerry"},
+	})
+	a.Equal(http.StatusOK, rec.Code)
+
+	a.Equal(1, ts.InvitesDB.CreateCallCount())
+	_, userID, aliasSuggestion := ts.InvitesDB.CreateArgsForCall(0)
+	a.EqualValues(ts.User.ID, userID)
+	a.EqualValues("jerry", aliasSuggestion)
+
+	doc, err := goquery.NewDocumentFromReader(rec.Body)
+	require.NoError(t, err, "failed to parse response")
+
+	assertLocalized(t, doc, []localizedElement{
+		{"title", "AdminInviteCreatedTitle"},
+		{"#welcome", "AdminInviteCreatedWelcome"},
+	})
+
+	wantURL := urlTo(router.CompleteInviteAccept, "token", testInvite)
+	wantURL.Host = ts.Domain
+	wantURL.Scheme = "https"
+
+	shownLink := doc.Find("#invite-accept-link").Text()
+	a.Equal(wantURL.String(), shownLink)
 }

--- a/web/handlers/admin/invites_test.go
+++ b/web/handlers/admin/invites_test.go
@@ -1,0 +1,47 @@
+package admin
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvitesCreateForm(t *testing.T) {
+	ts := newSession(t)
+	a := assert.New(t)
+
+	url, err := ts.Router.Get(router.AdminInvitesOverview).URL()
+	a.Nil(err)
+
+	html, resp := ts.Client.GetHTML(url.String())
+	a.Equal(http.StatusOK, resp.Code, "wrong HTTP status code")
+
+	assertLocalized(t, html, []localizedElement{
+		{"#welcome", "AdminInvitesWelcome"},
+		{"title", "AdminInvitesTitle"},
+	})
+
+	formSelection := html.Find("form#create-invite")
+	a.EqualValues(1, formSelection.Length())
+
+	method, ok := formSelection.Attr("method")
+	a.True(ok, "form has method set")
+	a.Equal("POST", method)
+
+	action, ok := formSelection.Attr("action")
+	a.True(ok, "form has action set")
+
+	addURL, err := ts.Router.Get(router.AdminInvitesCreate).URL()
+	a.NoError(err)
+
+	a.Equal(addURL.String(), action)
+
+	inputSelection := formSelection.Find("input[type=text]")
+	a.EqualValues(1, inputSelection.Length())
+
+	name, ok := inputSelection.Attr("name")
+	a.True(ok, "input has a name")
+	a.Equal("alias_suggestion", name, "wrong name on input field")
+}

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -55,8 +55,6 @@ func New(
 		return nil, err
 	}
 
-	var a *auth.Handler
-
 	r, err := render.New(web.Templates,
 		render.SetLogger(logger),
 		render.BaseTemplates("base.tmpl", "menu.tmpl"),
@@ -191,7 +189,7 @@ func New(
 		}, nil
 	})
 
-	a, err = auth.NewHandler(fs,
+	a, err := auth.NewHandler(fs,
 		auth.SetStore(store),
 		auth.SetErrorHandler(authErrH),
 		auth.SetNotAuthorizedHandler(notAuthorizedH),

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -44,6 +44,7 @@ func New(
 	as admindb.AuthWithSSBService,
 	fs admindb.AuthFallbackService,
 	al admindb.AllowListService,
+	is admindb.InviteService,
 	ns admindb.NoticesService,
 	ps admindb.PinnedNoticesService,
 ) (http.Handler, error) {
@@ -221,7 +222,12 @@ func New(
 	// hookup handlers to the router
 	roomsAuth.Handler(m, r, a)
 
-	adminHandler := a.Authenticate(admin.Handler(r, roomState, al, ns, ps))
+	adminHandler := a.Authenticate(admin.Handler(r,
+		roomState,
+		al,
+		is,
+		ns,
+		ps))
 	mainMux.Handle("/admin/", adminHandler)
 
 	m.Get(router.CompleteIndex).Handler(r.HTML("landing/index.tmpl", func(w http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/web/handlers/http_test.go
+++ b/web/handlers/http_test.go
@@ -68,7 +68,6 @@ func TestRestricted(t *testing.T) {
 	a := assert.New(t)
 
 	testURLs := []string{
-		// "/admin/",
 		"/admin/admin",
 		"/admin/admin/",
 	}
@@ -113,12 +112,12 @@ func TestFallbackAuth(t *testing.T) {
 	doc, resp := ts.Client.GetHTML(signInFormURL.String())
 	a.Equal(http.StatusOK, resp.Code)
 
-	assertCSRFTokenPresent(t, doc.Find("form"))
-
 	csrfCookie := resp.Result().Cookies()
 	a.Len(csrfCookie, 1, "should have one cookie for CSRF protection validation")
-	t.Log(csrfCookie)
+
 	jar.SetCookies(signInFormURL, csrfCookie)
+
+	assertCSRFTokenPresent(t, doc.Find("form"))
 
 	csrfTokenElem := doc.Find("input[type=hidden]")
 	a.Equal(1, csrfTokenElem.Length())
@@ -136,8 +135,6 @@ func TestFallbackAuth(t *testing.T) {
 		csrfName: []string{csrfValue},
 	}
 	ts.AuthFallbackDB.CheckReturns(int64(23), nil)
-
-	t.Log(loginVals)
 
 	signInURL, err := ts.Router.Get(router.AuthFallbackSignIn).URL()
 	r.Nil(err)
@@ -214,7 +211,6 @@ func TestFallbackAuth(t *testing.T) {
 	html, resp = ts.Client.GetHTML(durl)
 	a.Equal(http.StatusOK, resp.Code, "wrong HTTP status code")
 
-	t.Log(html.Find("body").Text())
 	assertLocalized(t, html, []localizedElement{
 		{"#welcome", "AdminDashboardWelcome"},
 		{"title", "AdminDashboardTitle"},
@@ -224,7 +220,6 @@ func TestFallbackAuth(t *testing.T) {
 }
 
 // utils
-
 type localizedElement struct {
 	Selector, Label string
 }
@@ -238,8 +233,7 @@ func assertLocalized(t *testing.T, html *goquery.Document, elems []localizedElem
 
 func assertCSRFTokenPresent(t *testing.T, sel *goquery.Selection) {
 	a := assert.New(t)
-
-	csrfField := sel.Find("input[name=gorilla.csrf.Token]")
+	csrfField := sel.Find("input[name='gorilla.csrf.Token']")
 	a.EqualValues(1, csrfField.Length(), "no csrf-token input tag")
 	tipe, ok := csrfField.Attr("type")
 	a.True(ok, "csrf input has a type")

--- a/web/handlers/http_test.go
+++ b/web/handlers/http_test.go
@@ -113,6 +113,8 @@ func TestFallbackAuth(t *testing.T) {
 	doc, resp := ts.Client.GetHTML(signInFormURL.String())
 	a.Equal(http.StatusOK, resp.Code)
 
+	assertCSRFTokenPresent(t, doc.Find("form"))
+
 	csrfCookie := resp.Result().Cookies()
 	a.Len(csrfCookie, 1, "should have one cookie for CSRF protection validation")
 	t.Log(csrfCookie)
@@ -232,4 +234,14 @@ func assertLocalized(t *testing.T, html *goquery.Document, elems []localizedElem
 	for i, pair := range elems {
 		a.Equal(pair.Label, html.Find(pair.Selector).Text(), "localized pair %d failed", i+1)
 	}
+}
+
+func assertCSRFTokenPresent(t *testing.T, sel *goquery.Selection) {
+	a := assert.New(t)
+
+	csrfField := sel.Find("input[name=gorilla.csrf.Token]")
+	a.EqualValues(1, csrfField.Length(), "no csrf-token input tag")
+	tipe, ok := csrfField.Attr("type")
+	a.True(ok, "csrf input has a type")
+	a.Equal("hidden", tipe, "wrong type on csrf field")
 }

--- a/web/handlers/invites.go
+++ b/web/handlers/invites.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"go.mindeco.de/http/render"
+
+	"github.com/gorilla/csrf"
+	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
+	weberrors "github.com/ssb-ngi-pointer/go-ssb-room/web/errors"
+	refs "go.mindeco.de/ssb-refs"
+)
+
+type inviteHandler struct {
+	r *render.Renderer
+
+	invites admindb.InviteService
+	alaises admindb.AliasService
+}
+
+func (h inviteHandler) acceptForm(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
+	inv, err := h.invites.GetByToken(req.Context(), req.URL.Query().Get("token"))
+	if err != nil {
+		if errors.Is(err, admindb.ErrNotFound) {
+			return nil, weberrors.ErrNotFound{What: "invite"}
+		}
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"Invite":         inv,
+		csrf.TemplateTag: csrf.TemplateField(req),
+	}, nil
+}
+
+func (h inviteHandler) consume(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if err := req.ParseForm(); err != nil {
+		return nil, weberrors.ErrBadRequest{Where: "form data", Details: err}
+	}
+
+	token := req.FormValue("token")
+
+	newMember, err := refs.ParseFeedRef(req.FormValue("new_member"))
+	if err != nil {
+		return nil, weberrors.ErrBadRequest{Where: "form data", Details: err}
+	}
+
+	inv, err := h.invites.Consume(req.Context(), token, *newMember)
+	if err != nil {
+		if errors.Is(err, admindb.ErrNotFound) {
+			return nil, weberrors.ErrNotFound{What: "invite"}
+		}
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"TunnelAddress": "pew pew",
+	}, nil
+}

--- a/web/handlers/invites.go
+++ b/web/handlers/invites.go
@@ -1,11 +1,14 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"go.mindeco.de/http/render"
 	"go.mindeco.de/logging"
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/csrf"
@@ -19,6 +22,9 @@ type inviteHandler struct {
 
 	invites admindb.InviteService
 	alaises admindb.AliasService
+
+	muxrpcHostAndPort string
+	roomPubKey        ed25519.PublicKey
 }
 
 func (h inviteHandler) acceptForm(rw http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -71,7 +77,11 @@ func (h inviteHandler) consume(rw http.ResponseWriter, req *http.Request) (inter
 		)
 	}
 
+	// TODO: hardcoded here just to be replaced soon with next version of ssb-uri
+	roomPubKey := base64.StdEncoding.EncodeToString(h.roomPubKey)
+	roomAddr := fmt.Sprintf("net:%s~shs:%s:SSB+Room+PSK3TLYC2T86EHQCUHBUHASCASE18JBV24=", h.muxrpcHostAndPort, roomPubKey)
+
 	return map[string]interface{}{
-		"TunnelAddress": "pew pew",
+		"RoomAddress": roomAddr,
 	}, nil
 }

--- a/web/handlers/invites_test.go
+++ b/web/handlers/invites_test.go
@@ -1,0 +1,1 @@
+package handlers

--- a/web/handlers/invites_test.go
+++ b/web/handlers/invites_test.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/base64"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
@@ -219,5 +221,12 @@ func TestInviteConsumeInvite(t *testing.T) {
 
 	consumedDoc, err := goquery.NewDocumentFromReader(resp.Body)
 	r.NoError(err)
-	t.Log(consumedDoc.Find("body").Text())
+
+	gotRA := consumedDoc.Find("#room-address").Text()
+
+	// TODO: this is just a cheap stub for actual ssb-uri parsing
+	a.True(strings.HasPrefix(gotRA, "net:localhost:8008~shs:"), "not for the test host: %s", gotRA)
+	a.True(strings.Contains(gotRA, base64.StdEncoding.EncodeToString(ts.NetworkInfo.PubKey)), "public key missing? %s", gotRA)
+	a.True(strings.HasSuffix(gotRA, ":SSB+Room+PSK3TLYC2T86EHQCUHBUHASCASE18JBV24="), "magic suffix missing: %s", gotRA)
+
 }

--- a/web/handlers/invites_test.go
+++ b/web/handlers/invites_test.go
@@ -1,1 +1,223 @@
 package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	refs "go.mindeco.de/ssb-refs"
+
+	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web"
+	weberrors "github.com/ssb-ngi-pointer/go-ssb-room/web/errors"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
+)
+
+func TestInviteShowAcceptForm(t *testing.T) {
+	ts := setup(t)
+
+	urlTo := web.NewURLTo(ts.Router)
+
+	t.Run("token doesnt exist", func(t *testing.T) {
+		a, r := assert.New(t), require.New(t)
+
+		testToken := "nonexistant-test-token"
+		acceptURL404 := urlTo(router.CompleteInviteAccept, "token", testToken)
+		r.NotNil(acceptURL404)
+
+		// prep the mocked db for http:404
+		ts.InvitesDB.GetByTokenReturns(admindb.Invite{}, admindb.ErrNotFound)
+
+		// request the form
+		acceptForm := acceptURL404.String()
+		t.Log(acceptForm)
+		doc, resp := ts.Client.GetHTML(acceptForm)
+		// 500 until https://github.com/ssb-ngi-pointer/go-ssb-room/issues/66 is fixed
+		a.Equal(http.StatusInternalServerError, resp.Code)
+
+		// check database calls
+		r.EqualValues(1, ts.InvitesDB.GetByTokenCallCount())
+		_, tokenFromArg := ts.InvitesDB.GetByTokenArgsForCall(0)
+		a.Equal(testToken, tokenFromArg)
+
+		// fix #66
+		// assertLocalized(t, doc, []localizedElement{
+		// 	{"#welcome", "AuthFallbackWelcome"},
+		// 	{"title", "AuthFallbackTitle"},
+		// })
+		gotErr := doc.Find("#errBody").Text()
+		wantErr := weberrors.ErrNotFound{What: "invite"}
+		a.EqualError(wantErr, gotErr)
+	})
+
+	wantNewMemberPlaceholder := "@                                            .ed25519"
+
+	t.Run("token DOES exist", func(t *testing.T) {
+		a, r := assert.New(t), require.New(t)
+
+		testToken := "existing-test-token"
+		validAcceptURL := urlTo(router.CompleteInviteAccept, "token", testToken)
+		r.NotNil(validAcceptURL)
+
+		// prep the mocked db for http:200
+		fakeExistingInvite := admindb.Invite{
+			ID:              1234,
+			AliasSuggestion: "bestie",
+		}
+		ts.InvitesDB.GetByTokenReturns(fakeExistingInvite, nil)
+
+		// request the form
+		validAcceptForm := validAcceptURL.String()
+		t.Log(validAcceptForm)
+		doc, resp := ts.Client.GetHTML(validAcceptForm)
+		a.Equal(http.StatusOK, resp.Code)
+
+		// check database calls
+		r.EqualValues(2, ts.InvitesDB.GetByTokenCallCount())
+		_, tokenFromArg := ts.InvitesDB.GetByTokenArgsForCall(1)
+		a.Equal(testToken, tokenFromArg)
+
+		assertLocalized(t, doc, []localizedElement{
+			{"#welcome", "InviteAcceptWelcome"},
+			{"title", "InviteAcceptTitle"},
+		})
+
+		form := doc.Find("form#consume")
+		r.Equal(1, form.Length())
+
+		assertCSRFTokenPresent(t, form)
+
+		assertInputsInForm(t, form, []inputElement{
+			{Name: "token", Type: "hidden", Value: testToken},
+			{Name: "alias", Type: "text", Value: fakeExistingInvite.AliasSuggestion},
+			{Name: "new_member", Type: "text", Placeholder: wantNewMemberPlaceholder},
+		})
+	})
+
+	t.Run("token DOES exist but has no suggested alias", func(t *testing.T) {
+		a, r := assert.New(t), require.New(t)
+
+		testToken := "existing-test-token-2"
+		validAcceptURL := urlTo(router.CompleteInviteAccept, "token", testToken)
+		r.NotNil(validAcceptURL)
+
+		inviteWithNoAlias := admindb.Invite{ID: 4321}
+		ts.InvitesDB.GetByTokenReturns(inviteWithNoAlias, nil)
+
+		// request the form
+		validAcceptForm := validAcceptURL.String()
+		t.Log(validAcceptForm)
+		doc, resp := ts.Client.GetHTML(validAcceptForm)
+		a.Equal(http.StatusOK, resp.Code)
+
+		// check database calls
+		r.EqualValues(3, ts.InvitesDB.GetByTokenCallCount())
+		_, tokenFromArg := ts.InvitesDB.GetByTokenArgsForCall(2)
+		a.Equal(testToken, tokenFromArg)
+
+		assertLocalized(t, doc, []localizedElement{
+			{"#welcome", "InviteAcceptWelcome"},
+			{"title", "InviteAcceptTitle"},
+		})
+
+		form := doc.Find("form#consume")
+		r.Equal(1, form.Length())
+
+		assertCSRFTokenPresent(t, form)
+
+		assertInputsInForm(t, form, []inputElement{
+			{Name: "token", Type: "hidden", Value: testToken},
+			{Name: "alias", Type: "text", Placeholder: "you@this.room"},
+			{Name: "new_member", Type: "text", Placeholder: wantNewMemberPlaceholder},
+		})
+	})
+}
+
+func TestInviteConsumeInvite(t *testing.T) {
+	ts := setup(t)
+	a, r := assert.New(t), require.New(t)
+	urlTo := web.NewURLTo(ts.Router)
+
+	testToken := "existing-test-token-2"
+	validAcceptURL := urlTo(router.CompleteInviteAccept, "token", testToken)
+	r.NotNil(validAcceptURL)
+	validAcceptURL.Host = "localhost"
+	validAcceptURL.Scheme = "https"
+
+	inviteWithNoAlias := admindb.Invite{ID: 4321}
+	ts.InvitesDB.GetByTokenReturns(inviteWithNoAlias, nil)
+
+	// request the form (for a valid csrf token)
+	validAcceptForm := validAcceptURL.String()
+	t.Log(validAcceptForm)
+	doc, resp := ts.Client.GetHTML(validAcceptForm)
+	a.Equal(http.StatusOK, resp.Code)
+
+	// we need a functional jar to unpack the Set-Cookie response for the csrf token
+	jar, err := cookiejar.New(nil)
+	r.NoError(err)
+
+	// update the jar
+	csrfCookie := resp.Result().Cookies()
+	a.Len(csrfCookie, 1, "should have one cookie for CSRF protection validation")
+	jar.SetCookies(validAcceptURL, csrfCookie)
+
+	// get the corresponding token from the page
+	csrfTokenElem := doc.Find("input[name='gorilla.csrf.Token']")
+	a.Equal(1, csrfTokenElem.Length())
+	csrfName, has := csrfTokenElem.Attr("name")
+	a.True(has, "should have a name attribute")
+	csrfValue, has := csrfTokenElem.Attr("value")
+	a.True(has, "should have value attribute")
+
+	// create the consume request
+	testNewMember := refs.FeedRef{
+		ID:   bytes.Repeat([]byte{1}, 32),
+		Algo: refs.RefAlgoFeedSSB1,
+	}
+	consumeVals := url.Values{
+		"token":      []string{testToken},
+		"new_member": []string{testNewMember.Ref()},
+
+		csrfName: []string{csrfValue},
+	}
+
+	// construct the consume endpoint url
+	consumeInviteURL, err := ts.Router.Get(router.CompleteInviteConsume).URL()
+	r.Nil(err)
+	consumeInviteURL.Host = "localhost"
+	consumeInviteURL.Scheme = "https"
+
+	// construct the header with Referer and Cookie
+	var csrfCookieHeader = http.Header(map[string][]string{})
+	csrfCookieHeader.Set("Referer", "https://localhost")
+	cs := jar.Cookies(consumeInviteURL)
+	r.Len(cs, 1, "expecting one cookie for csrf")
+	theCookie := cs[0].String()
+	a.NotEqual("", theCookie, "should have a new cookie")
+	csrfCookieHeader.Set("Cookie", theCookie)
+	ts.Client.SetHeaders(csrfCookieHeader)
+
+	// prepare the mock
+	ts.InvitesDB.ConsumeReturns(inviteWithNoAlias, nil)
+
+	// send the POST
+	resp = ts.Client.PostForm(consumeInviteURL.String(), consumeVals)
+	a.Equal(http.StatusOK, resp.Code, "wrong HTTP status code for sign in")
+
+	// check how consume was called
+	r.EqualValues(1, ts.InvitesDB.ConsumeCallCount())
+	_, tokenFromArg, newMemberRef := ts.InvitesDB.ConsumeArgsForCall(0)
+	a.Equal(testToken, tokenFromArg)
+	a.True(newMemberRef.Equal(&testNewMember))
+
+	consumedDoc, err := goquery.NewDocumentFromReader(resp.Body)
+	r.NoError(err)
+	t.Log(consumedDoc.Find("body").Text())
+}

--- a/web/handlers/setup_test.go
+++ b/web/handlers/setup_test.go
@@ -39,6 +39,8 @@ type testSession struct {
 	NoticeDB       *mockdb.FakeNoticesService
 
 	RoomState *roomstate.Manager
+
+	NetworkInfo NetworkInfo
 }
 
 var testI18N = justTheKeys()
@@ -69,6 +71,14 @@ func setup(t *testing.T) *testSession {
 	ts.PinnedDB.GetReturns(defaultNotice, nil)
 	ts.NoticeDB = new(mockdb.FakeNoticesService)
 
+	ts.NetworkInfo = NetworkInfo{
+		Domain:     "localhost",
+		PortMUXRPC: 8008,
+		PortHTTPS:  443,
+
+		PubKey: bytes.Repeat([]byte("test"), 8),
+	}
+
 	log, _ := logtest.KitLogger("complete", t)
 	ctx := context.TODO()
 	ts.RoomState = roomstate.NewManager(ctx, log)
@@ -78,7 +88,7 @@ func setup(t *testing.T) *testSession {
 	h, err := New(
 		log,
 		testRepo,
-		"localhost",
+		ts.NetworkInfo,
 		ts.RoomState,
 		Databases{
 			AuthWithSSB:   ts.AuthDB,

--- a/web/handlers/setup_test.go
+++ b/web/handlers/setup_test.go
@@ -34,6 +34,7 @@ type testSession struct {
 	AuthDB         *mockdb.FakeAuthWithSSBService
 	AuthFallbackDB *mockdb.FakeAuthFallbackService
 	AllowListDB    *mockdb.FakeAllowListService
+	InvitesDB      *mockdb.FakeInviteService
 	PinnedDB       *mockdb.FakePinnedNoticesService
 	NoticeDB       *mockdb.FakeNoticesService
 
@@ -59,6 +60,7 @@ func setup(t *testing.T) *testSession {
 	ts.AuthDB = new(mockdb.FakeAuthWithSSBService)
 	ts.AuthFallbackDB = new(mockdb.FakeAuthFallbackService)
 	ts.AllowListDB = new(mockdb.FakeAllowListService)
+	ts.InvitesDB = new(mockdb.FakeInviteService)
 	ts.PinnedDB = new(mockdb.FakePinnedNoticesService)
 	defaultNotice := &admindb.Notice{
 		Title:   "Default Notice Title",
@@ -76,10 +78,12 @@ func setup(t *testing.T) *testSession {
 	h, err := New(
 		log,
 		testRepo,
+		"localhost",
 		ts.RoomState,
 		ts.AuthDB,
 		ts.AuthFallbackDB,
 		ts.AllowListDB,
+		ts.InvitesDB,
 		ts.NoticeDB,
 		ts.PinnedDB,
 	)

--- a/web/handlers/setup_test.go
+++ b/web/handlers/setup_test.go
@@ -80,12 +80,14 @@ func setup(t *testing.T) *testSession {
 		testRepo,
 		"localhost",
 		ts.RoomState,
-		ts.AuthDB,
-		ts.AuthFallbackDB,
-		ts.AllowListDB,
-		ts.InvitesDB,
-		ts.NoticeDB,
-		ts.PinnedDB,
+		Databases{
+			AuthWithSSB:   ts.AuthDB,
+			AuthFallback:  ts.AuthFallbackDB,
+			AllowList:     ts.AllowListDB,
+			Invites:       ts.InvitesDB,
+			Notices:       ts.NoticeDB,
+			PinnedNotices: ts.PinnedDB,
+		},
 	)
 	if err != nil {
 		t.Fatal("setup: handler init failed:", err)

--- a/web/i18n/defaults/active.en.toml
+++ b/web/i18n/defaults/active.en.toml
@@ -2,6 +2,7 @@ GenericConfirm = "Yes"
 GenericGoBack = "Back"
 GenericSave = "Save"
 GenericPreview = "Preview"
+GenericLanguage = "Language"
 
 PageNotFound = "The requested page was not found."
 
@@ -45,9 +46,13 @@ NavAdminInvites = "Invites"
 NavAdminNotices = "Notices"
 
 InviteAccept = "Accept invite"
-InviteAcceptTitle = "Accept Invite
+InviteAcceptTitle = "Accept Invite"
 InviteAcceptWelcome = "elaborate welcome message for a new member with good words and stuff."
 InviteAcceptAliasSuggestion = "The persone who created thought you might like this alias:"
+InviteAcceptPublicKey = "Public Key"
+
+InviteConsumedTitle = "Invite accepted!"
+InviteConsumedWelcome = "Even more elaborate message that the person is now a member of the room!"
 
 NoticeEditTitle = "Edit Notice"
 NoticeList = "Notices"

--- a/web/i18n/defaults/active.en.toml
+++ b/web/i18n/defaults/active.en.toml
@@ -23,8 +23,14 @@ AdminAllowListRemove = "Remove"
 AdminAllowListRemoveConfirmWelcome = "Are you sure you want to remove this member? They will lose their alias, if they have one."
 AdminAllowListRemoveConfirmTitle = "Confirm member removal"
 
+AdminInvitesTitle = "Invites"
+AdminInvitesWelcome = "Here ytou can create invite tokens for people who are not yet members of this room."
+AdminInvitesAliasSuggestion = "Suggested alias (optional)"
+AdminInvitesRevoke = "Revoke"
+
 NavAdminLanding = "Home"
 NavAdminDashboard = "Dashboard"
+NavAdminInvites = "Invites"
 NavAdminNotices = "Notices"
 
 NoticeEditTitle = "Edit Notice"

--- a/web/i18n/defaults/active.en.toml
+++ b/web/i18n/defaults/active.en.toml
@@ -24,14 +24,30 @@ AdminAllowListRemoveConfirmWelcome = "Are you sure you want to remove this membe
 AdminAllowListRemoveConfirmTitle = "Confirm member removal"
 
 AdminInvitesTitle = "Invites"
-AdminInvitesWelcome = "Here ytou can create invite tokens for people who are not yet members of this room."
+AdminInvitesWelcome = "Create invite tokens for people who are not yet members of this room."
 AdminInvitesAliasSuggestion = "Suggested alias (optional)"
-AdminInvitesRevoke = "Revoke"
+AdminInviteRevoke = "Revoke"
+AdminInviteRevokeConfirmTitle = "Confirm invite revocation"
+AdminInviteRevokeConfirmWelcome = "Are you sure you want to remove this invite? If you already sent it out, they will not be able to use it."
+
+# TODO: add placeholder support to the template helpers (https://github.com/ssb-ngi-pointer/go-ssb-room/issues/60)
+AdminInviteCreatedBy = "Created by:"
+AdminInviteSuggestedAliasIs = "The suggested alias is:"
+AdminInviteSuggestedAliasIsShort = "Alias:"
+
+AdminInviteCreatedTitle = "Invite created successfully"
+AdminInviteCreatedWelcome = "Here is the invite you created. Please copy it before closing the page or it will be lost."
+
 
 NavAdminLanding = "Home"
 NavAdminDashboard = "Dashboard"
 NavAdminInvites = "Invites"
 NavAdminNotices = "Notices"
+
+InviteAccept = "Accept invite"
+InviteAcceptTitle = "Accept Invite
+InviteAcceptWelcome = "elaborate welcome message for a new member with good words and stuff."
+InviteAcceptAliasSuggestion = "The persone who created thought you might like this alias:"
 
 NoticeEditTitle = "Edit Notice"
 NoticeList = "Notices"

--- a/web/router/admin.go
+++ b/web/router/admin.go
@@ -14,6 +14,9 @@ const (
 	AdminAllowListRemoveConfirm = "admin:allow-list:remove:confirm"
 	AdminAllowListRemove        = "admin:allow-list:remove"
 
+	AdminInvitesOverview = "admin:invites:overview"
+	AdminInvitesCreate   = "admin:invites:create"
+
 	AdminNoticeEdit             = "admin:notice:edit"
 	AdminNoticeSave             = "admin:notice:save"
 	AdminNoticeDraftTranslation = "admin:notice:translation:draft"
@@ -38,6 +41,9 @@ func Admin(m *mux.Router) *mux.Router {
 	m.Path("/notice/translation/draft").Methods("GET").Name(AdminNoticeDraftTranslation)
 	m.Path("/notice/translation/add").Methods("POST").Name(AdminNoticeAddTranslation)
 	m.Path("/notice/save").Methods("POST").Name(AdminNoticeSave)
+
+	m.Path("/invites").Methods("GET").Name(AdminInvitesOverview)
+	m.Path("/invites/create").Methods("POST").Name(AdminInvitesCreate)
 
 	return m
 }

--- a/web/router/admin.go
+++ b/web/router/admin.go
@@ -14,8 +14,10 @@ const (
 	AdminAllowListRemoveConfirm = "admin:allow-list:remove:confirm"
 	AdminAllowListRemove        = "admin:allow-list:remove"
 
-	AdminInvitesOverview = "admin:invites:overview"
-	AdminInvitesCreate   = "admin:invites:create"
+	AdminInvitesOverview      = "admin:invites:overview"
+	AdminInvitesRevokeConfirm = "admin:invites:revoke:confirm"
+	AdminInvitesRevoke        = "admin:invites:revoke"
+	AdminInvitesCreate        = "admin:invites:create"
 
 	AdminNoticeEdit             = "admin:notice:edit"
 	AdminNoticeSave             = "admin:notice:save"
@@ -43,6 +45,8 @@ func Admin(m *mux.Router) *mux.Router {
 	m.Path("/notice/save").Methods("POST").Name(AdminNoticeSave)
 
 	m.Path("/invites").Methods("GET").Name(AdminInvitesOverview)
+	m.Path("/invites/revoke/confirm").Methods("GET").Name(AdminInvitesRevokeConfirm)
+	m.Path("/invites/revoke").Methods("POST").Name(AdminInvitesRevoke)
 	m.Path("/invites/create").Methods("POST").Name(AdminInvitesCreate)
 
 	return m

--- a/web/router/complete.go
+++ b/web/router/complete.go
@@ -13,6 +13,9 @@ const (
 
 	CompleteNoticeShow = "complete:notice:show"
 	CompleteNoticeList = "complete:notice:list"
+
+	CompleteInviteAccept  = "complete:invite:accept"
+	CompleteInviteConsume = "complete:invite:consume"
 )
 
 // CompleteApp constructs a mux.Router containing the routes for batch Complete html frontend
@@ -24,6 +27,9 @@ func CompleteApp() *mux.Router {
 
 	m.Path("/").Methods("GET").Name(CompleteIndex)
 	m.Path("/about").Methods("GET").Name(CompleteAbout)
+
+	m.Path("/invite/accept").Methods("GET").Name(CompleteInviteAccept)
+	m.Path("/invite/consume").Methods("POST").Name(CompleteInviteConsume)
 
 	m.Path("/notice/show").Methods("GET").Name(CompleteNoticeShow)
 	m.Path("/notice/list").Methods("GET").Name(CompleteNoticeList)

--- a/web/templates/admin/invite-created.tmpl
+++ b/web/templates/admin/invite-created.tmpl
@@ -1,0 +1,23 @@
+{{ define "title" }}{{i18n "AdminInviteCreatedTitle"}}{{ end }}
+{{ define "content" }}
+    <div class="flex flex-col justify-center items-center h-64">
+
+      <span
+        id="welcome"
+        class="text-center"
+      >{{i18n "AdminInviteCreatedWelcome"}}</span>
+
+      <a
+        href="{{urlTo "complete:invite:accept" "token" .Token}}"
+        id="accept-link"
+        class="px-4 h-8 shadow rounded flex flex-row justify-center items-center bg-white align-middle text-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-opacity-50"
+      >{{i18n "InviteAccept"}}</a>
+
+      <pre id="invite-accept-link">{{.AccepURL}}</pre>
+
+      {{if ne .AliasSuggestion ""}}
+        <!-- https://github.com/ssb-ngi-pointer/go-ssb-room/issues/60 -->
+        <p>{{i18n "AdminInviteSuggestedAliasIs"}} {{.AliasSuggestion}}</p>
+      {{end}}
+    </div>
+{{end}}

--- a/web/templates/admin/invite-list.tmpl
+++ b/web/templates/admin/invite-list.tmpl
@@ -36,12 +36,18 @@
     <li class="flex flex-row items-center h-12">
       <span
         class="font-mono truncate flex-auto text-gray-600 tracking-wider"
-      >{{.CreatedBy.Name}}</span>
+      >
+      <!-- https://github.com/ssb-ngi-pointer/go-ssb-room/issues/60 -->
+      {{i18n "AdminInviteCreatedBy"}} {{.CreatedBy.Name}}
+      {{if ne .AliasSuggestion ""}}
+        ({{i18n "AdminInviteSuggestedAliasIsShort"}} {{.AliasSuggestion}})
+      {{end}}
+      </span>
 
       <a
         href="{{urlTo "admin:invites:revoke:confirm" "id" .ID}}"
         class="pl-4 w-20 py-2 text-center text-gray-400 hover:text-red-600 font-bold cursor-pointer"
-      >{{i18n "AdminInvitesRevoke"}}</a>
+      >{{i18n "AdminInviteRevoke"}}</a>
     </li>
     {{end}}
   </ul>

--- a/web/templates/admin/invite-revoke-confirm.tmpl
+++ b/web/templates/admin/invite-revoke-confirm.tmpl
@@ -1,0 +1,35 @@
+{{ define "title" }}{{i18n "AdminInviteRevokeConfirmTitle"}}{{ end }}
+{{ define "content" }}
+    <div class="flex flex-col justify-center items-center h-64">
+
+      <span
+        id="welcome"
+        class="text-center"
+      >{{i18n "AdminInviteRevokeConfirmWelcome"}}</span>
+
+      <pre
+        class="my-4 font-mono truncate max-w-full text-lg text-gray-700"
+      >{{.Invite.CreatedBy.Name}}</pre>
+
+      {{if ne .Invite.AliasSuggestion ""}}
+        <!-- https://github.com/ssb-ngi-pointer/go-ssb-room/issues/60 -->
+        <p>{{i18n "AdminInviteSuggestedAliasIs"}} {{.Invite.AliasSuggestion}}</p>
+      {{end}}
+
+      <form id="confirm" action="{{urlTo "admin:invites:revoke"}}" method="POST">
+        {{ .csrfField }}
+        <input type="hidden" name="id" value={{.Invite.ID}}>
+        <div class="grid grid-cols-2 gap-4">
+          <a
+            href="javascript:history.back()"
+            class="px-4 h-8 shadow rounded flex flex-row justify-center items-center bg-white align-middle text-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-opacity-50"
+          >{{i18n "GenericGoBack"}}</a>
+
+          <button
+            type="submit"
+            class="shadow rounded px-4 h-8 text-gray-100 bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-pink-600 focus:ring-opacity-50"
+          >{{i18n "GenericConfirm"}}</button>
+        </div>
+      </form>
+    </div>
+{{end}}

--- a/web/templates/admin/invites.tmpl
+++ b/web/templates/admin/invites.tmpl
@@ -1,0 +1,89 @@
+{{ define "title" }}{{i18n "AdminInvitesTitle"}}{{ end }}
+{{ define "content" }}
+  <h1
+    class="text-3xl tracking-tight font-black text-black mt-2 mb-4"
+  >{{i18n "AdminInvitesTitle"}}</h1>
+
+  <p id="welcome" class="my-2">{{i18n "AdminInvitesWelcome"}}</p>
+
+  <p
+    id="inviteListCount"
+    class="text-lg font-bold my-2"
+  >{{i18npl "ListCount" .Count}}</p>
+
+  <ul id="theList" class="divide-y pb-4">
+    <form
+      id="create-invite"
+      action="{{urlTo "admin:invites:create"}}"
+      method="POST"
+    >
+      {{ .csrfField }}
+      <div class="flex flex-row items-center h-12">
+        <input
+          type="text"
+          name="alias_suggestion"
+          placeholder="{{i18n "AdminInvitesAliasSuggestion"}}"
+          class="font-mono truncate flex-auto tracking-wider h-12 text-gray-900 focus:outline-none focus:ring-1 focus:ring-green-500 focus:border-transparent placeholder-gray-300"
+        >
+        <input
+          type="submit"
+          value="{{i18n "GenericSave"}}"
+          class="pl-4 w-20 py-2 text-center text-green-500 hover:text-green-600 font-bold bg-transparent cursor-pointer"
+        >
+      </div>
+    </form>
+    {{range .Entries}}
+    <li class="flex flex-row items-center h-12">
+      <span
+        class="font-mono truncate flex-auto text-gray-600 tracking-wider"
+      >{{.CreatedBy.Name}}</span>
+
+      <a
+        href="{{urlTo "admin:invites:revoke:confirm" "id" .ID}}"
+        class="pl-4 w-20 py-2 text-center text-gray-400 hover:text-red-600 font-bold cursor-pointer"
+      >{{i18n "AdminInvitesRevoke"}}</a>
+    </li>
+    {{end}}
+  </ul>
+
+  {{$pageNums := .Paginator.PageNums}}
+  {{$view := .View}}
+  {{if gt $pageNums 1}}
+  <div class="flex flex-row justify-center">
+    {{if not .FirstInView}}
+      <a
+        href="{{urlTo "admin:invites:overview"}}?page=1"
+        class="rounded px-3 py-2 text-pink-600 border-transparent hover:border-pink-400 border-2"
+      >1</a>
+      <span
+        class="px-3 py-2 text-gray-400 border-2 border-transparent"
+      >..</span>
+    {{end}}
+
+    {{range $view.Pages}}
+      {{if le . $pageNums}}
+        {{if eq . $view.Current}}
+          <span
+            class="px-3 py-2 cursor-default text-gray-500 border-2 border-transparent"
+          >{{.}}</span>
+        {{else}}
+          <a
+            href="{{urlTo "admin:invites:overview"}}?page={{.}}"
+            class="rounded px-3 py-2 mx-1 text-pink-600 border-transparent hover:border-pink-400 border-2"
+          >{{.}}</a>
+        {{end}}
+      {{end}}
+    {{end}}
+
+    {{if not .LastInView}}
+      <span
+        class="px-3 py-2 text-gray-400 border-2 border-transparent"
+      >..</span>
+      <a
+        href="{{urlTo "admin:invites:overview"}}?page={{$view.Last}}"
+        class="rounded px-3 py-2 text-pink-600 border-transparent hover:border-pink-400 border-2"
+      >{{$view.Last}}</a>
+    {{end}}
+  </div>
+  {{end}}
+{{end}}

--- a/web/templates/admin/notice-edit.tmpl
+++ b/web/templates/admin/notice-edit.tmpl
@@ -38,7 +38,7 @@
     >{{.Notice.Content}}</textarea>
 
     <div class="my-4 flex flex-row items-center justify-start">
-      <label class="mr-2">Language</label>
+      <label class="mr-2">{{i18n "GenericLanguage"}}</label>
       <input
         type="text"
         name="language"

--- a/web/templates/invite/accept.tmpl
+++ b/web/templates/invite/accept.tmpl
@@ -7,11 +7,7 @@
       class="text-center"
     >{{ i18n "InviteAcceptWelcome" }}</span>
 
-
-    
-
-
-    <form id="confirm" action="{{urlTo "complete:invite:consume"}}" method="POST">
+    <form id="consume" action="{{urlTo "complete:invite:consume"}}" method="POST">
         {{ .csrfField }}
         <input type="hidden" name="token" value={{.Token}}>
         <div class="grid grid-cols-2 gap-4">
@@ -26,13 +22,16 @@
             <span class="ml-2 text-red-400">TODO: make this a dropdown</span>
           </div>
 
-          {{ if ne .Invite.AliasSuggestion "" }}
-            <p>{{ i18n "InviteAcceptAliasSuggestion" }}</p>
-            <input
-              name="alias"
+          <p>{{ i18n "InviteAcceptAliasSuggestion" }}</p>
+          <input
+            type="text"
+            name="alias"
+            {{ if ne .Invite.AliasSuggestion "" }}
               value="{{ .Invite.AliasSuggestion }}"
-            ></p>
-          {{ end }}
+            {{else}}
+              placeholder="you@this.room"
+            {{ end }}
+          >
 
           <a
             href="javascript:history.back()"

--- a/web/templates/invite/accept.tmpl
+++ b/web/templates/invite/accept.tmpl
@@ -1,0 +1,16 @@
+{{ define "title" }}{{i18n "InviteAcceptTitle"}}{{ end }}
+{{ define "content" }}
+  <div class="flex flex-col justify-center items-center h-64">
+
+    <span
+      id="welcome"
+      class="text-center"
+    >{{i18n "InviteAcceptWelcome"}}</span>
+
+
+    {{if ne .AliasSuggestion ""}}
+      <!-- https://github.com/ssb-ngi-pointer/go-ssb-room/issues/60 -->
+      <p>{{i18n "InviteAcceptAliasSuggestion"}} {{.AliasSuggestion}}</p>
+    {{end}}
+  </div>
+{{end}}

--- a/web/templates/invite/accept.tmpl
+++ b/web/templates/invite/accept.tmpl
@@ -1,16 +1,49 @@
-{{ define "title" }}{{i18n "InviteAcceptTitle"}}{{ end }}
+{{ define "title" }}{{ i18n "InviteAcceptTitle" }}{{ end }}
 {{ define "content" }}
   <div class="flex flex-col justify-center items-center h-64">
 
     <span
       id="welcome"
       class="text-center"
-    >{{i18n "InviteAcceptWelcome"}}</span>
+    >{{ i18n "InviteAcceptWelcome" }}</span>
 
 
-    {{if ne .AliasSuggestion ""}}
-      <!-- https://github.com/ssb-ngi-pointer/go-ssb-room/issues/60 -->
-      <p>{{i18n "InviteAcceptAliasSuggestion"}} {{.AliasSuggestion}}</p>
-    {{end}}
+    
+
+
+    <form id="confirm" action="{{urlTo "complete:invite:consume"}}" method="POST">
+        {{ .csrfField }}
+        <input type="hidden" name="token" value={{.Token}}>
+        <div class="grid grid-cols-2 gap-4">
+
+        <div class="my-4 flex flex-row items-center justify-start">
+            <label class="mr-2">{{ i18n "InviteAcceptPublicKey" }}</label>
+            <input
+              type="text"
+              name="new_member"
+              placeholder="@                                            .ed25519"
+              class="shadow rounded border border-transparent h-8 p-1 focus:outline-none focus:ring-2 focus:ring-pink-400 focus:border-transparent">
+            <span class="ml-2 text-red-400">TODO: make this a dropdown</span>
+          </div>
+
+          {{ if ne .Invite.AliasSuggestion "" }}
+            <p>{{ i18n "InviteAcceptAliasSuggestion" }}</p>
+            <input
+              name="alias"
+              value="{{ .Invite.AliasSuggestion }}"
+            ></p>
+          {{ end }}
+
+          <a
+            href="javascript:history.back()"
+            class="px-4 h-8 shadow rounded flex flex-row justify-center items-center bg-white align-middle text-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-opacity-50"
+          >{{i18n "GenericGoBack"}}</a>
+
+          <button
+            type="submit"
+            class="shadow rounded px-4 h-8 text-gray-100 bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-pink-600 focus:ring-opacity-50"
+          >{{i18n "GenericConfirm"}}</button>
+        </div>
+      </form>
   </div>
-{{end}}
+{{ end }}

--- a/web/templates/invite/consumed.tmpl
+++ b/web/templates/invite/consumed.tmpl
@@ -1,0 +1,12 @@
+{{ define "title" }}{{i18n "InviteConsumedTitle"}}{{ end }}
+{{ define "content" }}
+  <div class="flex flex-col justify-center items-center h-64">
+
+    <span
+      id="welcome"
+      class="text-center"
+    >{{i18n "InviteConsumedWelcome"}}</span>
+
+    <p class="color-red-600">TODO: present tunnel address and ssb uri redirect</p>
+  </div>
+{{end}}

--- a/web/templates/invite/consumed.tmpl
+++ b/web/templates/invite/consumed.tmpl
@@ -7,6 +7,7 @@
       class="text-center"
     >{{i18n "InviteConsumedWelcome"}}</span>
 
-    <p class="color-red-600">TODO: present tunnel address and ssb uri redirect</p>
+    <p class="color-red-600">TODO: this is just a <em>room v1 invite</em>. present tunnel address and ssb uri redirect</p>
+    <pre id="room-address">{{.RoomAddress}}</pre>
   </div>
 {{end}}

--- a/web/templates/menu.tmpl
+++ b/web/templates/menu.tmpl
@@ -28,6 +28,15 @@
   </a>
 
   <a
+    href="{{urlTo "admin:invites:overview"}}"
+    class="{{if current_page_is "admin:invites:overview"}}bg-gray-300 {{else}}hover:bg-gray-200 {{end}}pr-1 pl-2 py-3 sm:py-1 rounded-md flex flex-row items-center font-semibold text-sm text-gray-700 hover:text-gray-800 truncate"
+  >
+    <svg class="text-purple-600 w-4 h-4 mr-1" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M15,4A4,4 0 0,0 11,8A4,4 0 0,0 15,12A4,4 0 0,0 19,8A4,4 0 0,0 15,4M15,5.9C16.16,5.9 17.1,6.84 17.1,8C17.1,9.16 16.16,10.1 15,10.1A2.1,2.1 0 0,1 12.9,8A2.1,2.1 0 0,1 15,5.9M4,7V10H1V12H4V15H6V12H9V10H6V7H4M15,13C12.33,13 7,14.33 7,17V20H23V17C23,14.33 17.67,13 15,13M15,14.9C17.97,14.9 21.1,16.36 21.1,17V18.1H8.9V17C8.9,16.36 12,14.9 15,14.9Z" />
+    </svg>‍{{i18n "NavAdminInvites"}}
+  </a>
+
+  <a
     href="{{urlTo "complete:notice:list"}}"
     class="{{if current_page_is "complete:notice:list"}}bg-gray-300 {{else}}hover:bg-gray-200 {{end}}pr-1 pl-2 py-3 sm:py-1 rounded-md flex flex-row items-center font-semibold text-sm text-gray-700 hover:text-gray-800 truncate"
   >

--- a/web/user/helper.go
+++ b/web/user/helper.go
@@ -13,7 +13,7 @@ type roomUserContextKeyType string
 
 var roomUserContextKey roomUserContextKeyType = "ssb:room:httpcontext:user"
 
-// FromContext returns the user or nil of it's not logged in
+ // FromContext returns the user or nil if not logged in
 func FromContext(ctx context.Context) *admindb.User {
 	v := ctx.Value(roomUserContextKey)
 
@@ -25,11 +25,10 @@ func FromContext(ctx context.Context) *admindb.User {
 	return user
 }
 
-// ContextInjecter returns the middleware that injects the user value into the request context
+// ContextInjecter returns middleware for injecting a user id into the request context
 func ContextInjecter(fs admindb.AuthFallbackService, a *auth.Handler) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-
 			v, err := a.AuthenticateRequest(req)
 			if err != nil {
 				next.ServeHTTP(w, req)

--- a/web/user/helper.go
+++ b/web/user/helper.go
@@ -1,0 +1,71 @@
+// Package user implements helpers for accessing the currently logged in admin or moderator of an active request.
+package user
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
+	"go.mindeco.de/http/auth"
+)
+
+type roomUserContextKeyType string
+
+var roomUserContextKey roomUserContextKeyType = "ssb:room:httpcontext:user"
+
+// FromContext returns the user or nil of it's not logged in
+func FromContext(ctx context.Context) *admindb.User {
+	v := ctx.Value(roomUserContextKey)
+
+	user, ok := v.(*admindb.User)
+	if !ok {
+		return nil
+	}
+
+	return user
+}
+
+// ContextInjecter returns the middleware that injects the user value into the request context
+func ContextInjecter(fs admindb.AuthFallbackService, a *auth.Handler) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+			v, err := a.AuthenticateRequest(req)
+			if err != nil {
+				next.ServeHTTP(w, req)
+				return
+			}
+
+			uid, ok := v.(int64)
+			if !ok {
+				next.ServeHTTP(w, req)
+				return
+			}
+
+			user, err := fs.GetByID(req.Context(), uid)
+			if err != nil {
+				next.ServeHTTP(w, req)
+				return
+			}
+
+			ctx := context.WithValue(req.Context(), roomUserContextKey, user)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	}
+}
+
+// TemplateHelper returns a function to be used with the http/render package.
+// It has to return a function twice because the first is evaluated with the request before it gets passed onto html/template's FuncMap.
+func TemplateHelper() func(*http.Request) interface{} {
+	return func(r *http.Request) interface{} {
+		no := func() *admindb.User { return nil }
+
+		user := FromContext(r.Context())
+		if user == nil {
+			return no
+		}
+
+		yes := func() *admindb.User { return user }
+		return yes
+	}
+}

--- a/web/user/testing.go
+++ b/web/user/testing.go
@@ -8,7 +8,7 @@ import (
 )
 
 // MiddlewareForTests gives us a way to inject _test users_. It should not be used in production.
-// This is exists here because we need to use roomUserContextKey which shouldn't be exported either.
+// This is part of testing.go because we need to use roomUserContextKey, which shouldn't be exported either.
 // TODO: could be protected with an extra build tag.
 // (Sadly +build test does not exist https://github.com/golang/go/issues/21360 )
 func MiddlewareForTests(user *admindb.User) func(http.Handler) http.Handler {

--- a/web/user/testing.go
+++ b/web/user/testing.go
@@ -1,0 +1,21 @@
+package user
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ssb-ngi-pointer/go-ssb-room/admindb"
+)
+
+// MiddlewareForTests gives us a way to inject _test users_. It should not be used in production.
+// This is exists here because we need to use roomUserContextKey which shouldn't be exported either.
+// TODO: could be protected with an extra build tag.
+// (Sadly +build test does not exist https://github.com/golang/go/issues/21360 )
+func MiddlewareForTests(user *admindb.User) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := context.WithValue(req.Context(), roomUserContextKey, user)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	}
+}

--- a/web/utils.go
+++ b/web/utils.go
@@ -62,6 +62,7 @@ func NewURLTo(appRouter *mux.Router) func(string, ...interface{}) *url.URL {
 				params = append(params, v.Ref())
 			default:
 				level.Error(l).Log("msg", "invalid param type", "param", fmt.Sprintf("%T", p), "route", routeName)
+				return &url.URL{}
 			}
 		}
 


### PR DESCRIPTION
Let's merge #55 first.

* [x] add HTML overview page to create, list and revoke invites. (rough copy of the members overview)
* [x] create return page with the invite code
* [x] revocation pages
* [x] e2e HTTP tests for creation
  * [x] stored
  * [x] shown
* [x] accept
  * [x] page
  * [x] add to allow on accept
* [x] track feed of the user who created the invite
* [x] show ~~tunnel address~~ v1 room invite
* [x] tests for invite accept form
* [x] test for invite consumed page 

Future TODO:
* style the pages better
  * invites overview
  * created
*  register alias on accept
* ssb uri
* json/api endpoints
* e2e tests (create, accept, test to join the room over muxrpc)

miscellaneous tweaks:

* re-using pagination code between views (cf6c96d)
* found a way to untangle user lookup for is_logged_in and handler functions (15501ed)
* struct-ify database arguments (see d302423 and 78a8c3b)