### PR TITLE
Update insert user

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,13 @@ Aside: I would have used `sqlc` since it's a bit more minimal and uses hand writ
 ```bash
 cd cmd/insert-user
 go build
-./insert-user $HOME/.ssb-go-room/roomdb my-user
+# optional step: run a script to generate a valid ssb id @<pubkey>.ed25519, useful for trying things out quickly
+./generate-fake-id.sh   
+./insert-user -name <username> -key <@pubkey.ed25519>
 ```
-
 Then repeat your password twice and you are all set for development.
+
+Run `insert-user` without any flags to see all the options.
 
 ## Testing
 ### Rooms

--- a/cmd/insert-user/generate-fake-id.sh
+++ b/cmd/insert-user/generate-fake-id.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+id=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 -w0)
+echo "@$id.ed25519"

--- a/cmd/insert-user/generate-fake-id.sh
+++ b/cmd/insert-user/generate-fake-id.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 id=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 -w0)
-echo "@$id.ed25519"
+echo "@${id}.ed25519"

--- a/cmd/insert-user/main.go
+++ b/cmd/insert-user/main.go
@@ -65,11 +65,10 @@ func main() {
 
 		return nil
 	})
-
 	flag.Parse()
 
-	// we require at least 5 arguments: <executable> + -name <val> + -key <val>
-	//                               1              2     3       4    5
+	/* we require at least 5 arguments: <executable> + -name <val> + -key <val> */
+	/*                                  1              2     3       4    5     */
 	if len(os.Args) < 5 {
 		cliMissingArguments("please provide the default arguments -name and -key")
 	}
@@ -96,7 +95,7 @@ func main() {
 	check(err)
 
 	if !bytes.Equal(bytePassword, bytePasswordRepeat) {
-		fmt.Fprintln(os.Stderr, "passwords didn't match")
+		fmt.Fprintln(os.Stderr, "Passwords didn't match")
 		os.Exit(1)
 		return
 	}
@@ -108,7 +107,7 @@ func main() {
 	err = db.AuthFallback.Create(ctx, mid, os.Args[1], bytePassword)
 	check(err)
 
-	fmt.Fprintln(os.Stderr, "created member with ID", mid)
+	fmt.Fprintf(os.Stderr, "Created member %s (%s) with ID %d\n", name, role, mid)
 }
 
 func cliMissingArguments(message string) {

--- a/cmd/insert-user/main.go
+++ b/cmd/insert-user/main.go
@@ -30,20 +30,35 @@ func main() {
 	check(err)
 
 	var (
-		repoPath string
+		name     string
+		pubKey   *refs.FeedRef
 		role     roomdb.Role = roomdb.RoleAdmin
+		repoPath string
 	)
 
-	flag.StringVar(&repoPath, "repo", filepath.Join(u.HomeDir, ".ssb-go-room"), "where the repo of the room is located")
-	flag.Func("role", "which role the new member should have (ie moderator, admin, member. defaults to admin)", func(val string) error {
+	flag.StringVar(&name, "name", "", "username (used when logging into the room's web ui)")
+	flag.Func("key", "the public key of the user, format: @<base64-encoded public-key>.ed25519", func(val string) error {
+		if len(val) == 0 {
+			return fmt.Errorf("the public key is required. if you are just testing things out, generate one by running 'cmd/insert-user/generate-fake-id.sh'\n")
+		}
+		key, err := refs.ParseFeedRef(val)
+		if err != nil {
+			return fmt.Errorf("%s\n", err)
+		}
+		pubKey = key
+		return nil
+	})
+	flag.StringVar(&repoPath, "repo", filepath.Join(u.HomeDir, ".ssb-go-room"), "[optional] where the locally stored files of the room is located")
+	flag.Func("role", "[optional] which role the new member should have (values: mod[erator], admin, or member. default is admin)", func(val string) error {
 		switch strings.ToLower(val) {
 		case "admin":
 			role = roomdb.RoleAdmin
+		case "mod":
+			fallthrough
 		case "moderator":
-			role = roomdb.RoleAdmin
+			role = roomdb.RoleModerator
 		case "member":
 			role = roomdb.RoleMember
-
 		default:
 			return fmt.Errorf("unknown member role: %q", val)
 		}
@@ -53,20 +68,24 @@ func main() {
 
 	flag.Parse()
 
-	if len(os.Args) != 3 {
-		fmt.Fprintf(os.Stderr, "usage: %s <user-name> <@theirPublicKey.ed25519>\n", os.Args[0])
-		flag.Usage()
-		os.Exit(1)
-		return
+	// we require at least 5 arguments: <executable> + -name <val> + -key <val>
+	//                               1              2     3       4    5
+	if len(os.Args) < 5 {
+		cliMissingArguments("please provide the default arguments -name and -key")
+	}
+
+	if name == "" {
+		cliMissingArguments("please provide a username with -name <username>")
+	}
+
+	if pubKey == nil {
+		cliMissingArguments("please provide a public key with -key")
 	}
 
 	r := repo.New(repoPath)
 	db, err := sqlite.Open(r)
 	check(err)
 	defer db.Close()
-
-	pubKey, err := refs.ParseFeedRef(os.Args[2])
-	check(err)
 
 	fmt.Fprintln(os.Stderr, "Enter Password: ")
 	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
@@ -90,6 +109,13 @@ func main() {
 	check(err)
 
 	fmt.Fprintln(os.Stderr, "created member with ID", mid)
+}
+
+func cliMissingArguments(message string) {
+	executable := strings.TrimPrefix(os.Args[0], "./")
+	fmt.Fprintf(os.Stderr, "%s: %s\nusage:%s -name <user-name> -key <@<base64-encoded public key>.ed25519> <optional flags>\n", executable, message, executable)
+	flag.Usage()
+	os.Exit(1)
 }
 
 func check(err error) {


### PR DESCRIPTION
I updated the cli tool `insert-user` for a few reasons:
* there was a bug where you couldn't set moderators
* included more feedback when missing required arguments
* improved the error handling (it was hardwired to fail unless we input exactly 3 arguments, an assumption that was no longer valid :)

For convenience sake, I encoded a cool trick @cryptix showed me for generating a valid (but fake) ssb, in the bash script `generate-fake-id.sh`.

I also updated the readme to conform to the new behaviour.