### PR TITLE
support multiserverAddress in start-http-auth URI

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/unrolled/secure"
 	"go.cryptoscope.co/muxrpc/v2/debug"
 
+	"github.com/ssb-ngi-pointer/go-ssb-room/internal/network"
 	"github.com/ssb-ngi-pointer/go-ssb-room/internal/repo"
 	"github.com/ssb-ngi-pointer/go-ssb-room/internal/signinwithssb"
 	"github.com/ssb-ngi-pointer/go-ssb-room/roomdb/sqlite"
@@ -248,7 +249,7 @@ func runroomsrv() error {
 	webHandler, err := handlers.New(
 		kitlog.With(log, "package", "web"),
 		repo.New(repoDir),
-		handlers.NetworkInfo{
+		network.ServerEndpointDetails{
 			Domain:     httpsDomain,
 			PortHTTPS:  uint(portHTTP),
 			PortMUXRPC: uint(portMUXRPC),

--- a/internal/network/interface.go
+++ b/internal/network/interface.go
@@ -4,7 +4,9 @@ package network
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -15,6 +17,24 @@ import (
 	"go.cryptoscope.co/secretstream"
 	refs "go.mindeco.de/ssb-refs"
 )
+
+// ServerEndpointDetails encapsulates the endpoint information.
+// Like domain name of the room, it's ssb/secret-handshake public key and the HTTP and MUXRPC TCP ports.
+type ServerEndpointDetails struct {
+	PortMUXRPC uint
+	PortHTTPS  uint // 0 assumes default (443)
+
+	RoomID refs.FeedRef
+
+	Domain string
+}
+
+// MultiserverAddress returns net:domain:muxport~shs:roomPubKeyInBase64
+// ie: the room servers https://github.com/ssbc/multiserver-address
+func (sed ServerEndpointDetails) MultiserverAddress() string {
+	var roomPubKey = base64.StdEncoding.EncodeToString(sed.RoomID.PubKey())
+	return fmt.Sprintf("net:%s:%d~shs:%s", sed.Domain, sed.PortMUXRPC, roomPubKey)
+}
 
 // EndpointStat gives some information about a connected peer
 type EndpointStat struct {

--- a/internal/network/msaddr_test.go
+++ b/internal/network/msaddr_test.go
@@ -1,0 +1,31 @@
+package network
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	refs "go.mindeco.de/ssb-refs"
+)
+
+func TestMultiserverAddress(t *testing.T) {
+	a := assert.New(t)
+
+	var sed ServerEndpointDetails
+	sed.Domain = "the.ho.st"
+	sed.PortMUXRPC = 8008
+
+	sed.RoomID = refs.FeedRef{
+		ID:   bytes.Repeat([]byte("ohai"), 8),
+		Algo: "doesnt-matter", // not part of msaddr v1
+	}
+
+	gotMultiAddr := sed.MultiserverAddress()
+
+	a.Equal("net:the.ho.st:8008~shs:b2hhaW9oYWlvaGFpb2hhaW9oYWlvaGFpb2hhaW9oYWk=", gotMultiAddr)
+	a.True(strings.HasPrefix(gotMultiAddr, "net:the.ho.st:8008~shs:"), "not for the test host? %s", gotMultiAddr)
+	a.True(strings.HasSuffix(gotMultiAddr, base64.StdEncoding.EncodeToString(sed.RoomID.PubKey())), "public key missing? %s", gotMultiAddr)
+
+}

--- a/web/handlers/auth/withssb.go
+++ b/web/handlers/auth/withssb.go
@@ -60,7 +60,8 @@ const sessionLifetime = time.Hour * 24
 type WithSSBHandler struct {
 	render *render.Renderer
 
-	roomID refs.FeedRef
+	roomID            refs.FeedRef
+	muxrpcHostAndPort string
 
 	membersdb roomdb.MembersService
 	aliasesdb roomdb.AliasesService
@@ -77,6 +78,7 @@ func NewWithSSBHandler(
 	m *mux.Router,
 	r *render.Renderer,
 	roomID refs.FeedRef,
+	muxrpcHostAndPort string,
 	endpoints network.Endpoints,
 	aliasDB roomdb.AliasesService,
 	membersDB roomdb.MembersService,
@@ -88,6 +90,7 @@ func NewWithSSBHandler(
 	var ssb WithSSBHandler
 	ssb.render = r
 	ssb.roomID = roomID
+	ssb.muxrpcHostAndPort = muxrpcHostAndPort
 	ssb.aliasesdb = aliasDB
 	ssb.membersdb = membersDB
 	ssb.endpoints = endpoints
@@ -344,6 +347,9 @@ func (h WithSSBHandler) serverInitiated() (templateData, error) {
 	queryParams.Set("action", "start-http-auth")
 	queryParams.Set("sid", h.roomID.Ref())
 	queryParams.Set("sc", sc)
+	var roomPubKey = base64.StdEncoding.EncodeToString(h.roomID.PubKey())
+	var msaddr = fmt.Sprintf("net:%s~shs:%s", h.muxrpcHostAndPort, roomPubKey)
+	queryParams.Set("multiserverAddress", msaddr)
 
 	var startAuthURI url.URL
 	startAuthURI.Scheme = "ssb"

--- a/web/handlers/auth_test.go
+++ b/web/handlers/auth_test.go
@@ -431,6 +431,8 @@ func TestAuthWithSSBServerInitHappyPath(t *testing.T) {
 	a.Equal("start-http-auth", qry.Get("action"))
 	a.Equal(serverChallenge, qry.Get("sc"))
 	a.Equal(ts.NetworkInfo.RoomID.Ref(), qry.Get("sid"))
+	var msaddr = fmt.Sprintf("net:%s:%d~shs:%s", ts.NetworkInfo.Domain, ts.NetworkInfo.PortMUXRPC, base64.StdEncoding.EncodeToString(ts.NetworkInfo.RoomID.PubKey()))
+	a.Equal(msaddr, qry.Get("multiserverAddress"))
 
 	qrCode, has := html.Find("#start-auth-qrcode").Attr("src")
 	a.True(has, "should have the inline image data")

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -231,11 +231,13 @@ func New(
 	mainMux := &http.ServeMux{}
 
 	// start hooking up handlers to the router
+	var muxrpcHostAndPort = fmt.Sprintf("%s:%d", netInfo.Domain, netInfo.PortMUXRPC)
 
 	authWithSSB := roomsAuth.NewWithSSBHandler(
 		m,
 		r,
 		netInfo.RoomID,
+		muxrpcHostAndPort,
 		roomEndpoints,
 		dbs.Aliases,
 		dbs.Members,
@@ -305,7 +307,7 @@ func New(
 		db: dbs.Aliases,
 
 		roomID:            netInfo.RoomID,
-		muxrpcHostAndPort: fmt.Sprintf("%s:%d", netInfo.Domain, netInfo.PortMUXRPC),
+		muxrpcHostAndPort: muxrpcHostAndPort,
 	}
 	m.Get(router.CompleteAliasResolve).HandlerFunc(ah.resolve)
 
@@ -313,7 +315,7 @@ func New(
 		invites: dbs.Invites,
 
 		roomPubKey:        netInfo.RoomID.PubKey(),
-		muxrpcHostAndPort: fmt.Sprintf("%s:%d", netInfo.Domain, netInfo.PortMUXRPC),
+		muxrpcHostAndPort: muxrpcHostAndPort,
 	}
 	m.Get(router.CompleteInviteAccept).Handler(r.HTML("invite/accept.tmpl", ih.acceptForm))
 	m.Get(router.CompleteInviteConsume).Handler(r.HTML("invite/consumed.tmpl", ih.consume))

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/i18n"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/members"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
-	refs "go.mindeco.de/ssb-refs"
 )
 
 var HTMLTemplates = []string{
@@ -57,21 +56,11 @@ type Databases struct {
 	PinnedNotices roomdb.PinnedNoticesService
 }
 
-// NetworkInfo encapsulates the domain name of the room, it's ssb/secret-handshake public key and the HTTP and MUXRPC TCP ports.
-type NetworkInfo struct {
-	PortMUXRPC uint
-	PortHTTPS  uint // 0 assumes default (443)
-
-	RoomID refs.FeedRef
-
-	Domain string
-}
-
 // New initializes the whole web stack for rooms, with all the sub-modules and routing.
 func New(
 	logger logging.Interface,
 	repo repo.Interface,
-	netInfo NetworkInfo,
+	netInfo network.ServerEndpointDetails,
 	roomState *roomstate.Manager,
 	roomEndpoints network.Endpoints,
 	bridge *signinwithssb.SignalBridge,
@@ -236,8 +225,7 @@ func New(
 	authWithSSB := roomsAuth.NewWithSSBHandler(
 		m,
 		r,
-		netInfo.RoomID,
-		muxrpcHostAndPort,
+		netInfo,
 		roomEndpoints,
 		dbs.Aliases,
 		dbs.Members,
@@ -306,8 +294,7 @@ func New(
 
 		db: dbs.Aliases,
 
-		roomID:            netInfo.RoomID,
-		muxrpcHostAndPort: muxrpcHostAndPort,
+		roomEndpoint: netInfo,
 	}
 	m.Get(router.CompleteAliasResolve).HandlerFunc(ah.resolve)
 

--- a/web/handlers/setup_test.go
+++ b/web/handlers/setup_test.go
@@ -17,6 +17,7 @@ import (
 	"go.mindeco.de/http/tester"
 	"go.mindeco.de/logging/logtest"
 
+	"github.com/ssb-ngi-pointer/go-ssb-room/internal/network"
 	"github.com/ssb-ngi-pointer/go-ssb-room/internal/network/mocked"
 	"github.com/ssb-ngi-pointer/go-ssb-room/internal/repo"
 	"github.com/ssb-ngi-pointer/go-ssb-room/internal/signinwithssb"
@@ -49,7 +50,7 @@ type testSession struct {
 
 	SignalBridge *signinwithssb.SignalBridge
 
-	NetworkInfo NetworkInfo
+	NetworkInfo network.ServerEndpointDetails
 }
 
 var testI18N = justTheKeys()
@@ -85,7 +86,7 @@ func setup(t *testing.T) *testSession {
 
 	ts.MockedEndpoints = new(mocked.FakeEndpoints)
 
-	ts.NetworkInfo = NetworkInfo{
+	ts.NetworkInfo = network.ServerEndpointDetails{
 		Domain:     "localhost",
 		PortMUXRPC: 8008,
 		PortHTTPS:  443,


### PR DESCRIPTION
To match [ssb-http-auth-spec rev2021-03-29](https://ssb-ngi-pointer.github.io/ssb-http-auth-spec/#server-initiated-protocol)