### PR TITLE
Expand denylist

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -229,6 +229,7 @@ func runroomsrv() error {
 	// create the shs+muxrpc server
 	roomsrv, err := mksrv.New(
 		db.Members,
+		db.DeniedKeys,
 		db.Aliases,
 		db.AuthWithSSB,
 		bridge,

--- a/muxrpc/test/go/utils_test.go
+++ b/muxrpc/test/go/utils_test.go
@@ -90,7 +90,7 @@ func makeNamedTestBot(t testing.TB, name string, opts []roomsrv.Option) (roomdb.
 		}
 	})
 	sb := signinwithssb.NewSignalBridge()
-	theBot, err := roomsrv.New(db.Members, db.Aliases, db.AuthWithSSB, sb, db.Config, name, botOptions...)
+	theBot, err := roomsrv.New(db.Members, db.DeniedKeys, db.Aliases, db.AuthWithSSB, sb, db.Config, name, botOptions...)
 	r.NoError(err)
 	return db.Members, theBot
 }

--- a/muxrpc/test/nodejs/setup_test.go
+++ b/muxrpc/test/nodejs/setup_test.go
@@ -124,8 +124,9 @@ func (ts *testSession) startGoServer(
 	authSessionsDB := new(mockdb.FakeAuthWithSSBService)
 
 	fakeConfig := new(mockdb.FakeRoomConfig)
+  deniedKeysDB := new(mockdb.FakeDeniedKeysService)
 
-	srv, err := roomsrv.New(membersDB, aliasDB, authSessionsDB, sb, fakeConfig, "go.test.room.server", opts...)
+	srv, err := roomsrv.New(membersDB, deniedKeysDB, aliasDB, authSessionsDB, sb, fakeConfig, "go.test.room.server", opts...)
 	r.NoError(err, "failed to init tees a server")
 	ts.t.Logf("go server: %s", srv.Whoami().Ref())
 	ts.t.Cleanup(func() {

--- a/muxrpc/test/nodejs/setup_test.go
+++ b/muxrpc/test/nodejs/setup_test.go
@@ -124,7 +124,7 @@ func (ts *testSession) startGoServer(
 	authSessionsDB := new(mockdb.FakeAuthWithSSBService)
 
 	fakeConfig := new(mockdb.FakeRoomConfig)
-  deniedKeysDB := new(mockdb.FakeDeniedKeysService)
+	deniedKeysDB := new(mockdb.FakeDeniedKeysService)
 
 	srv, err := roomsrv.New(membersDB, deniedKeysDB, aliasDB, authSessionsDB, sb, fakeConfig, "go.test.room.server", opts...)
 	r.NoError(err, "failed to init tees a server")

--- a/roomdb/interface.go
+++ b/roomdb/interface.go
@@ -94,7 +94,7 @@ type DeniedKeysService interface {
 	// HasFeed returns true if a feed is on the list.
 	HasFeed(context.Context, refs.FeedRef) bool
 
-	// HasFeed returns true if a feed is on the list.
+	// HasID returns true if a member id is on the list.
 	HasID(context.Context, int64) bool
 
 	// GetByID returns the list entry for that ID or an error

--- a/roomsrv/init_network.go
+++ b/roomsrv/init_network.go
@@ -40,6 +40,11 @@ func (s *Server) initNetwork() error {
 			}
 		}
 
+		// if feed is in the deny list, deny their connection
+		if s.DeniedKeys.HasFeed(s.rootCtx, *remote) {
+			return nil, fmt.Errorf("this key has been banned")
+		}
+
 		// for community + open modes, allow all connections
 		return &s.public, nil
 	}

--- a/roomsrv/server.go
+++ b/roomsrv/server.go
@@ -65,8 +65,9 @@ type Server struct {
 
 	StateManager *roomstate.Manager
 
-	Members roomdb.MembersService
-	Aliases roomdb.AliasesService
+	Members    roomdb.MembersService
+	DeniedKeys roomdb.DeniedKeysService
+	Aliases    roomdb.AliasesService
 
 	authWithSSB       roomdb.AuthWithSSBService
 	authWithSSBBridge *signinwithssb.SignalBridge
@@ -79,6 +80,7 @@ func (s Server) Whoami() refs.FeedRef {
 
 func New(
 	membersdb roomdb.MembersService,
+	deniedkeysdb roomdb.DeniedKeysService,
 	aliasdb roomdb.AliasesService,
 	awsdb roomdb.AuthWithSSBService,
 	bridge *signinwithssb.SignalBridge,
@@ -90,6 +92,7 @@ func New(
 	s.authorizer = membersdb
 
 	s.Members = membersdb
+	s.DeniedKeys = deniedkeysdb
 	s.Aliases = aliasdb
 	s.Config = config
 

--- a/web/errors/badrequest.go
+++ b/web/errors/badrequest.go
@@ -34,3 +34,5 @@ func (f ErrForbidden) Error() string {
 }
 
 var ErrNotAuthorized = errors.New("rooms/web: not authorized")
+
+var ErrDenied = errors.New("rooms: this key has been banned")

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -309,6 +309,7 @@ func New(
 		config:        dbs.Config,
 		pinnedNotices: dbs.PinnedNotices,
 		invites:       dbs.Invites,
+		deniedKeys:    dbs.DeniedKeys,
 
 		networkInfo: netInfo,
 	}

--- a/web/handlers/invites_test.go
+++ b/web/handlers/invites_test.go
@@ -306,5 +306,5 @@ func TestInviteConsumptionDenied(t *testing.T) {
 	a.Equal("error", jsonConsumeResp.Status)
 
 	// invite should not be consumed
-	r.EqualValues(1, ts.InvitesDB.ConsumeCallCount())
+	r.EqualValues(0, ts.InvitesDB.ConsumeCallCount())
 }


### PR DESCRIPTION
This PR adds logic for denying invite consumption & connection establishment for banned keys (also called denied keys).

It's part of #96.