### PR TITLE
restyle the invites page

### DIFF
--- a/roomdb/sqlite/invites.go
+++ b/roomdb/sqlite/invites.go
@@ -190,6 +190,8 @@ func (i Invites) GetByID(ctx context.Context, id int64) (roomdb.Invite, error) {
 	inv.CreatedAt = entry.CreatedAt
 	inv.CreatedBy.ID = entry.R.CreatedByMember.ID
 	inv.CreatedBy.Role = roomdb.Role(entry.R.CreatedByMember.Role)
+	inv.CreatedBy.PubKey = entry.R.CreatedByMember.PubKey.FeedRef
+	inv.CreatedBy.Aliases = i.members.getAliases(entry.R.CreatedByMember)
 
 	return inv, nil
 }
@@ -213,6 +215,8 @@ func (i Invites) List(ctx context.Context) ([]roomdb.Invite, error) {
 			inv.ID = e.ID
 			inv.CreatedAt = e.CreatedAt
 			inv.CreatedBy.ID = e.R.CreatedByMember.ID
+			inv.CreatedBy.PubKey = e.R.CreatedByMember.PubKey.FeedRef
+			inv.CreatedBy.Aliases = i.members.getAliases(e.R.CreatedByMember)
 
 			invs[idx] = inv
 		}

--- a/roomdb/sqlite/members.go
+++ b/roomdb/sqlite/members.go
@@ -20,7 +20,7 @@ type Members struct {
 	db *sql.DB
 }
 
-func getAliases(mEntry *models.Member) []roomdb.Alias {
+func (m Members) getAliases(mEntry *models.Member) []roomdb.Alias {
 	if mEntry.R == nil || mEntry.R.Aliases == nil {
 		return make([]roomdb.Alias, 0)
 	}
@@ -78,7 +78,7 @@ func (m Members) GetByID(ctx context.Context, mid int64) (roomdb.Member, error) 
 		ID:      entry.ID,
 		Role:    roomdb.Role(entry.Role),
 		PubKey:  entry.PubKey.FeedRef,
-		Aliases: getAliases(entry),
+		Aliases: m.getAliases(entry),
 	}, nil
 }
 
@@ -107,7 +107,7 @@ func (m Members) List(ctx context.Context) ([]roomdb.Member, error) {
 		members[i].ID = entry.ID
 		members[i].Role = roomdb.Role(entry.Role)
 		members[i].PubKey = entry.PubKey.FeedRef
-		members[i].Aliases = getAliases(entry)
+		members[i].Aliases = m.getAliases(entry)
 	}
 
 	return members, nil

--- a/roomdb/sqlite/members.go
+++ b/roomdb/sqlite/members.go
@@ -20,7 +20,8 @@ type Members struct {
 	db *sql.DB
 }
 
-func (m Members) getAliases(mEntry *models.Member) []roomdb.Alias {
+// getAliases returns the JOIN-ed aliases for a member as a the wanted roomdb type.
+func (Members) getAliases(mEntry *models.Member) []roomdb.Alias {
 	if mEntry.R == nil || mEntry.R.Aliases == nil {
 		return make([]roomdb.Alias, 0)
 	}

--- a/roomdb/types.go
+++ b/roomdb/types.go
@@ -147,7 +147,7 @@ func (aa ErrAlreadyAdded) Error() string {
 	return fmt.Sprintf("roomdb: the item (%s) is already on the list", aa.Ref.Ref())
 }
 
-// Invite is a combination of an invite id, who created it and an (optional) alias suggestion.
+// Invite is a combination of an invite id, who created it and when.
 // The token itself is only visible from the db.Create function and stored hashed in the database
 type Invite struct {
 	ID int64

--- a/web/handlers/admin/invites_test.go
+++ b/web/handlers/admin/invites_test.go
@@ -93,10 +93,6 @@ func TestInvitesCreateForm(t *testing.T) {
 	a.NoError(err)
 
 	a.Equal(addURL.String(), action)
-
-	webassert.ElementsInForm(t, formSelection, []webassert.FormElement{
-		{Name: "alias_suggestion", Type: "text"},
-	})
 }
 
 func TestInvitesCreate(t *testing.T) {

--- a/web/i18n/defaults/active.en.toml
+++ b/web/i18n/defaults/active.en.toml
@@ -62,14 +62,13 @@ AdminMemberDetailsExclusion = "Exclusion from this room"
 AdminMemberDetailsRemove = "Remove member"
 
 AdminInvitesTitle = "Invites"
-AdminInvitesWelcome = "Create invite tokens for people who are not yet members of this room. At the same time as you create an invite, you can also (optionally) attach an alias to it so that the person who receives the invite can automatically use that claim that alias for themselves."
-AdminInvitesAliasSuggestion = "(Optional) Alias suggestion"
+AdminInvitesWelcome = "Create invite tokens for people who are not yet members of this room. On this page you can also see previously created invites that are still not unclaimed by new members."
+AdminInvitesCreate = "Create new invite"
 AdminInvitesCreatedAtColumn = "Created at"
 AdminInvitesCreatorColumn = "Created by"
-AdminInvitesAliasColumn = "Alias suggestion"
-AdminInvitesSummaryFrom = "From"
-AdminInvitesSummaryTo = "to"
+AdminInvitesActionColumn = "Action"
 AdminInviteRevoke = "Revoke"
+
 AdminInviteRevokeConfirmTitle = "Confirm invite revocation"
 AdminInviteRevokeConfirmWelcome = "Are you sure you want to remove this invite? If you already sent it out, they will not be able to use it."
 

--- a/web/styles/input.css
+++ b/web/styles/input.css
@@ -14,7 +14,7 @@ html {
 }
 
 .has-tooltip:hover .tooltip {
-  @apply visible z-50 p-1 rounded border border-gray-200 bg-gray-100 shadow-lg ml-4 text-sm;
+  @apply visible z-50 p-1 rounded border border-gray-200 bg-gray-100 text-gray-600 shadow-lg ml-4 text-sm;
 }
 
 /* custom markdown styling */

--- a/web/templates/admin/invite-list.tmpl
+++ b/web/templates/admin/invite-list.tmpl
@@ -9,52 +9,64 @@
 
   <table class="table-auto w-full self-stretch mt-4 mb-8">
     <thead class="block sm:table-header-group">
-      <tr class="sm:h-12 sm:table-row flex flex-col items-stretch">
-        <td class="sm:w-3 sm:table-cell block" colspan="2">
+      <tr class="sm:table-row flex flex-col items-stretch">
+        <td class="sm:w-9/12 sm:table-cell block" colspan="2">
           <div
             id="invite-list-count"
             class="inline ml-0 rounded-full px-3 py-1 tracking-tight font-black text-white bg-gradient-to-r from-pink-400 to-red-400"
           >{{i18npl "AdminInvitesCount" .Count}}</div>
         </td>
-        <td class="sm:w-1/2 sm:pl-2 pr-0 sm:table-cell block sm:my-0 my-4" colspan="2">
+        <td
+          colspan="2"
+          class="sm:w-3/12 sm:pl-2 pr-0 sm:table-cell sm:my-0 my-4 block"
+          >
           <form
             id="create-invite"
             action="{{urlTo "admin:invites:create"}}"
             method="POST"
-          >
+            class="flex flex-row justify-start sm:justify-end"
+            >
             {{ .csrfField }}
-            <div class="h-10 flex flex-row items-center rounded-full ring-2 ring-green-400 bg-white">
-              <input
-                type="text"
-                name="alias_suggestion"
-                placeholder="{{i18n "AdminInvitesAliasSuggestion"}}"
-                class="h-10 ml-4 w-1/2 truncate flex-auto tracking-wider text-gray-900 focus:outline-none placeholder-gray-300"
-              >
-              <input
-                type="submit"
-                value="{{i18n "GenericCreate"}}"
-                class="pl-4 pr-3 w-20 py-2 text-center text-green-500 hover:text-green-600 font-bold bg-transparent cursor-pointer"
-              >
-            </div>
+            <button
+              type="submit"
+              class="shadow rounded px-3 py-1.5 text-green-600 ring-1 ring-green-400 bg-white hover:bg-green-500 hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-green-400"
+              >{{i18n "AdminInvitesCreate"}}</button>
           </form>
         </td>
       </tr>
-      <tr class="hidden sm:table-row h-8 uppercase text-sm text-gray-400">
-        <th class="w-10 text-center pl-3 pr-6">{{i18n "AdminInvitesCreatedAtColumn"}}</th>
-        <th class="w-1/2 text-left px-6">{{i18n "AdminInvitesCreatorColumn"}}</th>
-        <th class="w-0"></th>
+      <tr class="h-4"></tr>
+      <tr class="h-8 uppercase text-sm text-gray-400">
+        <th class="w-3/12 hidden sm:table-cell text-left pl-3 pr-6">{{i18n "AdminInvitesCreatedAtColumn"}}</th>
+        <th class="w-6/12 text-left sm:px-2">{{i18n "AdminInvitesCreatorColumn"}}</th>
+        <th class="w-3/12 hidden sm:table-cell text-right pr-3">{{i18n "AdminInvitesActionColumn"}}</th>
       </tr>
     </thead>
+
     <tbody id="the-table-rows" class="divide-y">
       {{range .Entries}}
+        {{$creator := .CreatedBy.PubKey.Ref}}
+        {{$creatorIsAlias := false}}
+        {{range $index, $alias := .CreatedBy.Aliases}}
+          {{if eq $index 0}}
+            {{$creator = $alias.Name}}
+            {{$creatorIsAlias = true}}
+          {{end}}
+        {{end}}
       <tr class="h-12 hidden sm:table-row">
-        <td class="pl-3 pr-6 text-gray-400 text-center">
-        <div class="has-tooltip">
-          {{human_time .CreatedAt}}
-          <span class="tooltip">{{.CreatedAt.Format "2006-01-02T15:04:05.00"}}</span>
-        </div>
+        <td class="w-3/12 pl-3 pr-6 text-gray-400 text-left">
+          <div class="has-tooltip inline">
+            {{human_time .CreatedAt}}
+            <span class="tooltip">{{.CreatedAt.Format "2006-01-02T15:04:05.00"}}</span>
+          </div>
         </td>
-        <td class="pl-2 pr-3">
+        <td class="w-6/12 px-2">
+          {{if eq $creatorIsAlias true}}
+            {{$creator}}
+          {{else}}
+            <span class="font-mono text-sm w-32 truncate block">{{$creator}}</span>
+          {{end}}
+        </td>
+        <td class="w-3/12 pl-2 pr-3 text-right">
           <a
             href="{{urlTo "admin:invites:revoke:confirm" "id" .ID}}"
             class="pl-2 w-20 py-2 text-center text-gray-400 hover:text-red-600 font-bold cursor-pointer"
@@ -62,12 +74,20 @@
         </td>
       </tr>
       <tr class="h-12 table-row sm:hidden">
-        <td class="flex flex-row items-center" colspan="4">
-          <span class="flex-1">{{i18n "AdminInvitesSummaryFrom"}} <b>{{.CreatedBy.PubKey.Ref }}</b> {{i18n "AdminInvitesSummaryTo"}}</span>
+        <td class="flex flex-row items-center mt-0.5" colspan="3">
+          <span class="flex-1 flex flex-row items-center">
+            {{if eq $creatorIsAlias true}}
+              {{$creator}}, {{human_time .CreatedAt}}
+            {{else}}
+              <span
+                class="font-mono w-32 truncate inline-block"
+                >{{$creator}}</span>, {{human_time .CreatedAt}}
+            {{end}}
+          </span>
           <a
             href="{{urlTo "admin:invites:revoke:confirm" "id" .ID}}"
             class="pl-4 w-20 py-2 text-center text-gray-400 hover:text-red-600 font-bold cursor-pointer"
-          >{{i18n "AdminInviteRevoke"}}</a>
+            >{{i18n "AdminInviteRevoke"}}</a>
         </td>
       </tr>
       {{end}}

--- a/web/templates/admin/invite-revoke-confirm.tmpl
+++ b/web/templates/admin/invite-revoke-confirm.tmpl
@@ -7,17 +7,18 @@
         class="text-center"
       >{{i18n "AdminInviteRevokeConfirmWelcome"}}</span>
 
+      {{$creator := .Invite.CreatedBy.PubKey.Ref}}
+      {{range $index, $alias := .Invite.CreatedBy.Aliases}}
+        {{if eq $index 0}}
+          {{$creator = $alias.Name}}
+        {{end}}
+      {{end}}
       <pre
         class="my-4 font-mono truncate max-w-full text-lg text-gray-700"
-      >{{.Invite.CreatedBy.Nickname}}</pre>
-
-      {{if ne .Invite.AliasSuggestion ""}}
-        <!-- https://github.com/ssb-ngi-pointer/go-ssb-room/issues/60 -->
-        <p>{{i18n "AdminInviteSuggestedAliasIs"}} {{.Invite.AliasSuggestion}}</p>
-      {{end}}
+      >{{.Invite.CreatedAt.Format "2006-01-02T15:04:05.00"}} ({{$creator}})</pre>
 
       <form id="confirm" action="{{urlTo "admin:invites:revoke"}}" method="POST">
-        {{ .csrfField }}
+        {{.csrfField}}
         <input type="hidden" name="id" value={{.Invite.ID}}>
         <div class="grid grid-cols-2 gap-4">
           <a


### PR DESCRIPTION
Picks the creator's 1st alias to show (assuming that other aliases are just alternative aliases, and assuming that you can figure out the alternative aliases from the Members page)

| Page | Desktop | Mobile |
|----|---|---|
| **Invites** (creator has alias) | ![Screenshot from 2021-04-08 13-05-56](https://user-images.githubusercontent.com/90512/114009639-fd170900-986b-11eb-972f-633464f43c66.png) | [Open](https://user-images.githubusercontent.com/90512/114009682-07390780-986c-11eb-962d-35724fee3d43.png) |
| **Invites** (creator has no alias) | ![Screenshot from 2021-04-08 13-07-56](https://user-images.githubusercontent.com/90512/114009757-1a4bd780-986c-11eb-989f-dba9c7ba5b48.png) | [Open](https://user-images.githubusercontent.com/90512/114009769-1ddf5e80-986c-11eb-9ec1-f01a9c182180.png) |
| **Revoke** (creator has alias | ![Screenshot from 2021-04-08 13-06-27](https://user-images.githubusercontent.com/90512/114009951-4bc4a300-986c-11eb-9c29-142c6a8b7087.png) | Boring |
| **Revoke** (creator has no alias) | ![Screenshot from 2021-04-08 13-08-03](https://user-images.githubusercontent.com/90512/114010042-626afa00-986c-11eb-9639-ef6ea317e6d1.png) | Boring |

