### PR TITLE
show home on the footer, and edit notice when logged in

### DIFF
--- a/web/templates/base.tmpl
+++ b/web/templates/base.tmpl
@@ -71,11 +71,21 @@
     {{$cocUrl := urlToNotice "NoticeCodeOfConduct"}}
     {{$ppUrl := urlToNotice "NoticePrivacyPolicy"}}
     <footer class="mb-4 flex flex-row items-center justify-center divide-x divide-gray-300">
+      <a
+        href="{{urlTo "complete:index"}}"
+        class="px-4 text-gray-500 hover:underline"
+        >{{i18n "NavAdminLanding"}}</a>
       {{if $cocUrl}}
-      <a href="{{$cocUrl}}" class="px-4 text-gray-500 hover:underline">{{i18n "NoticeCodeOfConduct"}}</a>
+      <a
+        href="{{$cocUrl}}"
+        class="px-4 text-gray-500 hover:underline"
+        >{{i18n "NoticeCodeOfConduct"}}</a>
       {{end}}
       {{if $ppUrl}}
-      <a href="{{$ppUrl}}" class="px-4 text-gray-500 hover:underline">{{i18n "NoticePrivacyPolicy"}}</a>
+      <a
+        href="{{$ppUrl}}"
+        class="px-4 text-gray-500 hover:underline"
+        >{{i18n "NoticePrivacyPolicy"}}</a>
       {{end}}
     </footer>
     {{end}}

--- a/web/templates/landing/index.tmpl
+++ b/web/templates/landing/index.tmpl
@@ -7,4 +7,13 @@
   <div class="markdown">
     {{.Content}}
   </div>
+
+  <div class="h-8"></div>
+  {{if is_logged_in}}
+    <a
+      id="edit-notice"
+      href="{{urlTo "admin:notice:edit" "id" .ID}}"
+      class="self-start shadow rounded px-4 h-8 flex flex-row justify-center items-center text-gray-100 bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-pink-600 focus:ring-opacity-50"
+    >{{i18n "NoticeEditTitle"}}</a>
+  {{end}}
 {{end}}

--- a/web/templates/notice/show.tmpl
+++ b/web/templates/notice/show.tmpl
@@ -8,7 +8,7 @@
     {{.Content}}
   </div>
 
-  <div class="h-10"></div>
+  <div class="h-8"></div>
   {{if is_logged_in}}
     <a
       id="edit-notice"


### PR DESCRIPTION
Just a tweak. 

- Footer: allows people to go back to the landing page if they navigated to CoC or Privacy Pol
- Edit notice: when you're logged in and you press "home" on the left menu, you should be able to edit the home notice if you have the permission

![Screenshot from 2021-04-08 13-25-07](https://user-images.githubusercontent.com/90512/114011775-49fbdf00-986e-11eb-8218-c1e4d65bbda4.png)
