### PR TITLE
fix server-initiated success redirect JS

### DIFF
--- a/web/assets/login-events.js
+++ b/web/assets/login-events.js
@@ -23,6 +23,7 @@ evtSource.addEventListener('failed', (e) => {
   console.error(e.data);
 });
 
+// prepare for the case that the success event happens while the browser is not on screen.
 let hasFocus = true;
 window.addEventListener('blur', () => {
   hasFocus = false;

--- a/web/assets/login-events.js
+++ b/web/assets/login-events.js
@@ -23,8 +23,20 @@ evtSource.addEventListener('failed', (e) => {
   console.error(e.data);
 });
 
+let hasFocus = true;
+window.addEventListener('blur', () => {
+  hasFocus = false;
+});
+
 evtSource.addEventListener('success', (e) => {
   waitingElem.classList.add('hidden');
   evtSource.close();
-  window.location = `/withssb/finalize?token=${e.data}`;
+  const redirectTo = `/withssb/finalize?token=${e.data}`
+  if (hasFocus) {
+    window.location.replace(redirectTo);
+  } else {
+    window.addEventListener('focus', () => {
+      window.location.replace(redirectTo);
+    });
+  }
 });

--- a/web/assets/login-events.js
+++ b/web/assets/login-events.js
@@ -36,6 +36,7 @@ evtSource.addEventListener('success', (e) => {
   if (hasFocus) {
     window.location.replace(redirectTo);
   } else {
+  // wait for the browser to be back in focus and redirect then
     window.addEventListener('focus', () => {
       window.location.replace(redirectTo);
     });


### PR DESCRIPTION
Fixes #131. Turned out there was no logical or network problem, there was just a visual glitch: we need to do the page redirect only when the browser is focused. (Android's Firefox in this case, but should be a safe assumption for other browsers as well, desktop or mobile).