### PR TITLE
Test conn establishment & denied peers

### DIFF
--- a/muxrpc/test/go/deny_test.go
+++ b/muxrpc/test/go/deny_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+
+package go_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ssb-ngi-pointer/go-ssb-room/roomdb"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.cryptoscope.co/muxrpc/v2"
+	refs "go.mindeco.de/ssb-refs"
+)
+
+// This test denies connections for keys that have been added to the deny list database, DeniedKeys.
+// Two peers try to connect to the server, A and B. A is a member, while B has had their key banned (added to the deny
+// list).
+func TestConnEstablishmentDeniedKey(t *testing.T) {
+	// defer leakcheck.Check(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	theBots := createServerAndBots(t, ctx, 2)
+
+	r := require.New(t)
+	a := assert.New(t)
+
+	const (
+		indexSrv = iota
+		indexA
+		indexB
+	)
+
+	serv := theBots[indexSrv].Server
+	botA := theBots[indexA].Server
+	botB := theBots[indexB].Server
+
+	// allow A, deny B
+	theBots[indexSrv].Members.Add(ctx, botA.Whoami(), roomdb.RoleMember)
+	// since we want to verify denied keys in particular, let us both:
+	// a) add B as a member
+	theBots[indexSrv].Members.Add(ctx, botB.Whoami(), roomdb.RoleMember)
+	// b) ban B by adding them to the DeniedKeys database
+	theBots[indexSrv].Server.DeniedKeys.Add(ctx, botB.Whoami(), "rude")
+
+	// hack: allow bots to dial the server
+	theBots[indexA].Members.Add(ctx, serv.Whoami(), roomdb.RoleMember)
+	theBots[indexB].Members.Add(ctx, serv.Whoami(), roomdb.RoleMember)
+
+	// dial up B->A and C->A
+	// should work (we allowed A)
+	err := botA.Network.Connect(ctx, serv.Network.GetListenAddr())
+	r.NoError(err, "connect A to the Server")
+
+	// shouldn't work (we banned B)
+	err = botB.Network.Connect(ctx, serv.Network.GetListenAddr())
+	r.NoError(err, "connect B to the Server") // we dont see an error because it just establishes the tcp connection
+
+	t.Log("letting handshaking settle..")
+	time.Sleep(1 * time.Second)
+
+	var srvWho struct {
+		ID refs.FeedRef
+	}
+
+	endpointB, has := botB.Network.GetEndpointFor(serv.Whoami())
+	r.False(has, "botB has an endpoint for the server!")
+	if endpointB != nil {
+		a.Nil(endpointB, "should not have an endpoint on B")
+		err = endpointB.Async(ctx, &srvWho, muxrpc.TypeJSON, muxrpc.Method{"whoami"})
+		r.Error(err)
+		t.Log(srvWho.ID.Ref())
+	}
+
+	endpointA, has := botA.Network.GetEndpointFor(serv.Whoami())
+	r.True(has, "botA has no endpoint for the server")
+
+	err = endpointA.Async(ctx, &srvWho, muxrpc.TypeJSON, muxrpc.Method{"whoami"})
+	r.NoError(err)
+
+	t.Log("server whoami:", srvWho.ID.Ref())
+	a.True(serv.Whoami().Equal(&srvWho.ID))
+
+	cancel()
+}

--- a/muxrpc/test/go/simple_test.go
+++ b/muxrpc/test/go/simple_test.go
@@ -33,9 +33,8 @@ func TestTunnelServerSimple(t *testing.T) {
 	botA := theBots[indexA].Server
 	botB := theBots[indexB].Server
 
-	// allow both clients
+	// only allow A
 	theBots[indexSrv].Members.Add(ctx, botA.Whoami(), roomdb.RoleMember)
-	theBots[indexSrv].Members.Add(ctx, botB.Whoami(), roomdb.RoleMember)
 
 	// allow bots to dial the remote
 	theBots[indexA].Members.Add(ctx, serv.Whoami(), roomdb.RoleMember)
@@ -51,15 +50,15 @@ func TestTunnelServerSimple(t *testing.T) {
 	err = botB.Network.Connect(ctx, serv.Network.GetListenAddr())
 	r.NoError(err, "connect B to the Server") // we dont see an error because it just establishes the tcp connection
 
-	// t.Log("letting handshaking settle..")
-	// time.Sleep(1 * time.Second)
+	t.Log("letting handshaking settle..")
+	time.Sleep(1 * time.Second)
 
 	var srvWho struct {
 		ID refs.FeedRef
 	}
 
 	endpointB, has := botB.Network.GetEndpointFor(serv.Whoami())
-	r.False(has, "botB has an endpoint for the server!")
+	r.False(has, "botB has an endpoint for the server")
 	if endpointB != nil {
 		a.Nil(endpointB, "should not have an endpoint on B")
 		err = endpointB.Async(ctx, &srvWho, muxrpc.TypeJSON, muxrpc.Method{"whoami"})

--- a/muxrpc/test/go/utils_test.go
+++ b/muxrpc/test/go/utils_test.go
@@ -94,6 +94,10 @@ func makeNamedTestBot(t testing.TB, name string, opts []roomsrv.Option) (roomdb.
 			t.Log("db close failed: ", err)
 		}
 	})
+
+	err = db.Config.SetPrivacyMode(context.TODO(), roomdb.ModeRestricted)
+	r.NoError(err)
+
 	sb := signinwithssb.NewSignalBridge()
 	theBot, err := roomsrv.New(db.Members, db.DeniedKeys, db.Aliases, db.AuthWithSSB, sb, db.Config, name, botOptions...)
 	r.NoError(err)

--- a/muxrpc/test/go/utils_test.go
+++ b/muxrpc/test/go/utils_test.go
@@ -4,13 +4,18 @@ package go_test
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/ssb-ngi-pointer/go-ssb-room/roomdb"
 
@@ -93,4 +98,54 @@ func makeNamedTestBot(t testing.TB, name string, opts []roomsrv.Option) (roomdb.
 	theBot, err := roomsrv.New(db.Members, db.DeniedKeys, db.Aliases, db.AuthWithSSB, sb, db.Config, name, botOptions...)
 	r.NoError(err)
 	return db.Members, theBot
+}
+
+type testBot struct {
+	Server  *roomsrv.Server
+	Members roomdb.MembersService
+}
+
+func createServerAndBots(t *testing.T, ctx context.Context, count uint) []testBot {
+	testInit(t)
+	r := require.New(t)
+
+	botgroup, ctx := errgroup.WithContext(ctx)
+
+	bs := newBotServer(ctx, mainLog)
+
+	appKey := make([]byte, 32)
+	rand.Read(appKey)
+
+	netOpts := []roomsrv.Option{
+		roomsrv.WithAppKey(appKey),
+		roomsrv.WithContext(ctx),
+	}
+	theBots := []testBot{}
+
+	srvsMembers, serv := makeNamedTestBot(t, "srv", netOpts)
+	botgroup.Go(bs.Serve(serv))
+	theBots = append(theBots, testBot{
+		Server:  serv,
+		Members: srvsMembers,
+	})
+
+	for i := uint(1); i < count+1; i++ {
+		botMembers, botSrv := makeNamedTestBot(t, fmt.Sprintf("%d", i), netOpts)
+		botgroup.Go(bs.Serve(botSrv))
+		theBots = append(theBots, testBot{
+			Server:  botSrv,
+			Members: botMembers,
+		})
+	}
+
+	t.Cleanup(func() {
+		time.Sleep(1 * time.Second)
+		for _, bot := range theBots {
+			bot.Server.Shutdown()
+			r.NoError(bot.Server.Close())
+		}
+		r.NoError(botgroup.Wait())
+	})
+
+	return theBots
 }

--- a/roomsrv/init_network.go
+++ b/roomsrv/init_network.go
@@ -28,7 +28,7 @@ func (s *Server) initNetwork() error {
 			return &s.master, nil
 		}
 
-		pm, err := s.Config.GetPrivacyMode(nil)
+		pm, err := s.Config.GetPrivacyMode(s.rootCtx)
 		if err != nil {
 			return nil, fmt.Errorf("running with unknown privacy mode")
 		}


### PR DESCRIPTION
This PR refactors the existing muxrpc go tests slightly (cleaning up names & moving util functions to the util file). 

Primarily, though, it attempts to verify that banned peers can't successfully establish a connection with the room.