### PR TITLE
Add language picker 

### DIFF
--- a/muxrpc/test/nodejs/package-lock.json
+++ b/muxrpc/test/nodejs/package-lock.json
@@ -1,9 +1,3978 @@
 {
   "name": "go-ssb-rooms-tests",
   "version": "1.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "go-ssb-rooms-tests",
+      "version": "1.0.1",
+      "dependencies": {
+        "run-parallel": "^1.1.9",
+        "run-series": "^1.1.9",
+        "secret-stack": "^6.3.2",
+        "sodium-native": "^3.2.0",
+        "ssb-config": "^3.4.5",
+        "ssb-conn": "^2.1.0",
+        "ssb-db2": "^1.18.5",
+        "ssb-keys": "^8.1.0",
+        "ssb-replicate": "^1.3.2",
+        "ssb-room": "^1.3.0",
+        "ssb-room-client": "^0.10.0",
+        "tap-spec": "^5.0.0",
+        "tape": "^5.2.2"
+      }
+    },
+    "node_modules/@minireq/browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@minireq/browser/-/browser-2.0.0.tgz",
+      "integrity": "sha512-0A6KOXLL+EQlFaLjNKvH2bRxy8fKPH/DNBy7IXq36LdSPubbzmJ8qoPTxTCfFsTVSFhozEhn48u8QjoyEQq2BQ==",
+      "dependencies": {
+        "@minireq/common": "^2.0.0"
+      }
+    },
+    "node_modules/@minireq/common": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@minireq/common/-/common-2.0.0.tgz",
+      "integrity": "sha512-dVza/V5g0uURv2rnJ2vNchb8WlrOVlkLHscfO74poiFB4nPqnYz+8bLVY2uwH9W/1SAG73kEZPOsGibBnn7rBg=="
+    },
+    "node_modules/@minireq/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@minireq/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-qaXdz7sQb45Q8r2MGUadP1Wj8cjQ+srG0FhXGiv+5HoD1Mdl3hEqRy1OFjgiAY8KCgt4tIV8W5heYZ6H94A42w==",
+      "dependencies": {
+        "@minireq/common": "^2.0.0"
+      }
+    },
+    "node_modules/@sammacbeth/random-access-idb-mutable-file": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@sammacbeth/random-access-idb-mutable-file/-/random-access-idb-mutable-file-0.1.1.tgz",
+      "integrity": "sha512-jHnpuu2qtFgwCmhgrpCCk3/hU3XqXTqhidh4XmcTijkVsGwh1c2T0+r2hkHs1PRfsxeimx8qDAotphpRoYB2eg==",
+      "dependencies": {
+        "buffer": "5.1.0",
+        "random-access-storage": "1.3.0"
+      }
+    },
+    "node_modules/@sammacbeth/random-access-idb-mutable-file/node_modules/buffer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/@sammacbeth/random-access-idb-mutable-file/node_modules/random-access-storage": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
+      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
+      "dependencies": {
+        "inherits": "^2.0.3"
+      }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+    },
+    "node_modules/abstract-leveldown": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dependencies": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aligned-block-file": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.2.2.tgz",
+      "integrity": "sha512-2Sy0hWhifVb8ycNFJgicL8fDPL2Ct1r62XOVxXnykn36z22MPZwnQlCmB2viQlY/lwfuO67GaQjUZ0rJgdVP7Q==",
+      "dependencies": {
+        "hashlru": "^2.1.0",
+        "int53": "^1.0.0",
+        "mkdirp": "^0.5.1",
+        "obv": "^0.0.1",
+        "rwlock": "^5.0.0",
+        "uint48be": "^2.0.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/append-batch": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.2.tgz",
+      "integrity": "sha1-1zm0UDiIJF1Hkz1HVisRSf+d+Lc="
+    },
+    "node_modules/array-differ": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-append-only-log": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/async-append-only-log/-/async-append-only-log-3.0.7.tgz",
+      "integrity": "sha512-/6W+vsTSDg+rVUAFYknugtLeNDtS8BMfJ7clMF4kGXNS5nprb+Gx+ndG1QNaD8eFeEv6lSyGMeWJ7KxHuEpkKg==",
+      "dependencies": {
+        "debug": "^4.2.0",
+        "hashlru": "^2.3.0",
+        "lodash.debounce": "^4.0.8",
+        "looper": "^4.0.0",
+        "ltgt": "^2.2.1",
+        "obz": "^1.0.2",
+        "polyraf": "^1.1.0",
+        "push-stream": "^11.0.0",
+        "push-stream-to-pull-stream": "^1.0.3"
+      }
+    },
+    "node_modules/async-append-only-log/node_modules/looper": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
+      "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
+    },
+    "node_modules/atomic-file": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-2.1.1.tgz",
+      "integrity": "sha512-Eh6pW+fRC2/1RxPq3hO8+PkZKv+wujzKky2MP/n69eC8yMkbNFfuEb/riZHqf13M7gr6Hvglpk/kISgBSBb6bQ==",
+      "dependencies": {
+        "flumecodec": "0.0.1",
+        "idb-kv-store": "^4.5.0",
+        "mutexify": "^1.2.0"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/atomically-universal": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/atomically-universal/-/atomically-universal-0.1.1.tgz",
+      "integrity": "sha512-0bqmz+wKlA9hIiH/C4R3K8dpsVV6mM/X76QZ70LMHW0XzCDXzxdWD5gfkmRXxTM5txlbYE/06iz0IziohUQVzw==",
+      "dependencies": {
+        "atomically": "^1.7.0",
+        "idb-kv-store": "^4.5.0",
+        "promisify-4loc": "^1.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dependencies": {
+        "array-filter": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "node_modules/bash-color": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
+      "integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM="
+    },
+    "node_modules/binary-search-bounds": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
+    },
+    "node_modules/bipf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bipf/-/bipf-1.4.0.tgz",
+      "integrity": "sha512-8b2T/OWIRI73kcPXhI+jqK+0QyxRlZ6HIzQBK8tRxIZ2NO0dBxJ4T9eeX6XsYEHy2cqM69n+rOZyVjhvRUGRig==",
+      "dependencies": {
+        "varint": "^5.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
+    "node_modules/buffer-from": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+    },
+    "node_modules/buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "node_modules/bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chloride": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.0.tgz",
+      "integrity": "sha512-Fgz7EaWswRjRBeft6pCkg8STSQTQT/5GrRZlbtlx5hkhFi/X1RSIhSustfe2GsbySVZF2DuxsWri8GDFJ/SkvQ==",
+      "dependencies": {
+        "sodium-browserify": "^1.2.7",
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "sodium-chloride": "^1.1.2",
+        "sodium-native": "^3.0.0"
+      }
+    },
+    "node_modules/chloride-test": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.4.tgz",
+      "integrity": "sha512-9vhoi1qXSBPn6//ZxIgSe3M2QhKHzIPZQzmrZgmPADsqW0Jxpe3db1e7aGSRUMXbxAQ04SfypdT8dGaSvIvKDw==",
+      "dependencies": {
+        "json-buffer": "^2.0.11"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/cpu-percentage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cpu-percentage/-/cpu-percentage-1.0.3.tgz",
+      "integrity": "sha1-ho/ZCS9DnR75X0qF5fpLnwfvyVw=",
+      "engines": {
+        "node": ">=6.1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deferred-leveldown": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
+      "dependencies": {
+        "abstract-leveldown": "~6.2.1",
+        "inherits": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+    },
+    "node_modules/dotignore": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "ignored": "bin/ignored"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
+    "node_modules/ed2curve": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
+      "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
+      "dependencies": {
+        "tweetnacl": "0.x.x"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "node_modules/ejs": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
+      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-down": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+      "dependencies": {
+        "abstract-leveldown": "^6.2.1",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
+        "object-inspect": "^1.9.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-abstract/node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "node_modules/es-abstract/node_modules/has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-abstract/node_modules/is-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/explain-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
+      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
+    },
+    "node_modules/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/express/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/fastintcompression": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fastintcompression/-/fastintcompression-0.0.4.tgz",
+      "integrity": "sha512-sRtejNHcWjJl0Fr+gsbybbgOKKj0sQYvv7rA787EbeFu1fMpmzjHuBW8fLBImSZeqDuR++TZU2n60mRrpAUR9g=="
+    },
+    "node_modules/fastpriorityqueue": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/fastpriorityqueue/-/fastpriorityqueue-0.6.3.tgz",
+      "integrity": "sha512-l4Whw9/MDkl/0XuqZEzGE/sw9T7dIxuUnxqq4ZJDLt8AE45j8wkx4/nBRZm50aQ9kN71NB9mwQzglLsvQGROsw=="
+    },
+    "node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flumecodec": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
+      "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
+      "dependencies": {
+        "level-codec": "^6.2.0"
+      }
+    },
+    "node_modules/flumecodec/node_modules/level-codec": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
+      "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+    },
+    "node_modules/flumelog-offset": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.4.4.tgz",
+      "integrity": "sha512-sakCD+dVx541h3VeVq3Ti2lWPRrJf8PBRmnbm9EMBVLJnZkS3UD2lAlClZROxgKbh/JkMPyffvhDGv4VHNCVbA==",
+      "dependencies": {
+        "aligned-block-file": "^1.2.0",
+        "append-batch": "0.0.2",
+        "hashlru": "^2.3.0",
+        "int53": "^1.0.0",
+        "looper": "^4.0.0",
+        "obv": "0.0.1",
+        "pull-cursor": "^3.0.0",
+        "pull-looper": "^1.0.0",
+        "pull-stream": "^3.6.13",
+        "uint48be": "^2.0.1"
+      }
+    },
+    "node_modules/flumelog-offset/node_modules/looper": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
+      "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "node_modules/forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
+      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-network2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/has-network2/-/has-network2-0.0.3.tgz",
+      "integrity": "sha512-EvEZguA+LkyiS8G/Qks5I6imKnM2Z3NPN3eoQhviUQ7O6/d8nyZ7sDozBk6kTIA+Qj/S/V8ubRA1rqJcxc3qBQ=="
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
+    "node_modules/hoox": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/hoox/-/hoox-0.0.1.tgz",
+      "integrity": "sha1-CKdNknKpzIOujmu+AwPw7nZDIJQ="
+    },
+    "node_modules/http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/idb-kv-store": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/idb-kv-store/-/idb-kv-store-4.5.0.tgz",
+      "integrity": "sha512-snvtAQRforYUI+C2+45L2LBJy/0/uQUffxv8/uwiS98fSUoXHVrFPClgzWZWxT0drwkLHJRm9inZcYzTR42GLA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "promisize": "^1.1.2"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "node_modules/ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+    },
+    "node_modules/increment-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
+      "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0="
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/int53": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/int53/-/int53-1.0.0.tgz",
+      "integrity": "sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w=="
+    },
+    "node_modules/ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-canonical-base64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-canonical-base64/-/is-canonical-base64-1.1.1.tgz",
+      "integrity": "sha512-o6t/DwgEapC0bsloqtegAQyZzQXaQ5+8fzsyf2KmLqupC2ifLFq/lMQiFCJeGpdSrK1o6GL+WW2lRU050lLlFg=="
+    },
+    "node_modules/is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-options/-/is-options-1.0.1.tgz",
+      "integrity": "sha512-2Xj8sA0zDrAcaoWfBiNmc6VPWAgKDpim0T3J9Djq7vbm1UjwbUWzeuLu/FwC46g3cBbAn0E5R0xwVtOobM6Xxg=="
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-valid-domain": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.17.tgz",
+      "integrity": "sha512-w0UWEXyrgPeWWwj9FVT14y4/dSIqWgjDkzxbsGDFpT+QRbyS9HTwwNvGus2IOR/03GzCpeChzSWK9Bo9WlStDA=="
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "node_modules/jitdb": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/jitdb/-/jitdb-2.3.3.tgz",
+      "integrity": "sha512-wSB+iNzPm/Qcp1lKg8olKL0zeZdAhDVXLpWLKLWtqWN/vpHeu7vKmYxClsxhmV4YhZ/Hjzzi0oXBY8hVqKHQTA==",
+      "dependencies": {
+        "atomically-universal": "^0.1.0",
+        "binary-search-bounds": "^2.0.4",
+        "bipf": "^1.4.0",
+        "debug": "^4.2.0",
+        "fastpriorityqueue": "^0.6.3",
+        "idb-kv-store": "^4.5.0",
+        "jsesc": "^3.0.2",
+        "mkdirp": "^1.0.4",
+        "multicb": "1.2.2",
+        "obz": "~1.0.3",
+        "promisify-4loc": "1.0.0",
+        "pull-async": "~1.0.0",
+        "pull-awaitable": "^1.0.0",
+        "pull-cat": "~1.1.11",
+        "pull-stream": "^3.6.14",
+        "push-stream": "^11.0.0",
+        "push-stream-to-pull-stream": "^1.0.3",
+        "sanitize-filename": "^1.6.3",
+        "traverse": "^0.6.6",
+        "typedarray-to-buffer": "^4.0.0",
+        "typedfastbitset": "~0.2.1"
+      }
+    },
+    "node_modules/jitdb/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jitdb/node_modules/obz": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/obz/-/obz-1.0.3.tgz",
+      "integrity": "sha512-rH3U4eLHsV+OgkOS29ULiC9JLspwMCyCIH/+BglLPXDxQs13IK8AGD+nVmkGXqGN5JefZu85YhfIi05CsOKWPw=="
+    },
+    "node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
+      "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
+    },
+    "node_modules/level": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
+      "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+      "dependencies": {
+        "level-js": "^5.0.0",
+        "level-packager": "^5.1.0",
+        "leveldown": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/level-codec": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-concat-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "dependencies": {
+        "errno": "~0.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-iterator-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-js": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
+      "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
+      "dependencies": {
+        "abstract-leveldown": "~6.2.3",
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.3",
+        "ltgt": "^2.1.2"
+      }
+    },
+    "node_modules/level-packager": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+      "dependencies": {
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-post": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+      "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
+      "dependencies": {
+        "ltgt": "^2.1.2"
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leveldown": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
+      "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
+      "dependencies": {
+        "abstract-leveldown": "~6.2.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/leveldown/node_modules/node-gyp-build": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
+      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/levelup": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
+      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
+      "dependencies": {
+        "deferred-leveldown": "~5.3.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/libsodium": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.8.tgz",
+      "integrity": "sha512-/Qc+APf0jbeWSaeEruH0L1/tbbT+sbf884ZL0/zV/0JXaDPBzYkKbyb/wmxMHgAHzm3t6gqe7bOOXAVwfqVikQ=="
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.8.tgz",
+      "integrity": "sha512-PDhPWXBqd/SaqAFUBgH2Ux7b3VEEJgyD6BQB+VdNFJb9PbExGr/T/myc/MBoSvl8qLzfm0W0IVByOQS5L1MrCg==",
+      "dependencies": {
+        "libsodium": "0.7.8"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "node_modules/looper": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+      "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+    },
+    "node_modules/ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
+    "node_modules/map-merge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/map-merge/-/map-merge-1.1.0.tgz",
+      "integrity": "sha1-am/FjJXYqrRsK93kTVFbbuBvzjQ="
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+      "dependencies": {
+        "mime-db": "1.45.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "node_modules/monotonic-timestamp": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz",
+      "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
+    },
+    "node_modules/moo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+    },
+    "node_modules/mri": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/multicb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/multicb/-/multicb-1.2.2.tgz",
+      "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
+    },
+    "node_modules/multimatch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+      "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/multiserver": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-3.7.0.tgz",
+      "integrity": "sha512-70SSDMNT+e3VsDG4x7OKFW8+UqyZsBWfKD9rAvsRWCbMe9ySODheJCZ91Xyha5FrA32UtWIHGSY3m5jATfEmVQ==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "multicb": "^1.2.2",
+        "multiserver-scopes": "^1.0.0",
+        "pull-stream": "^3.6.1",
+        "pull-ws": "^3.3.0",
+        "secret-handshake": "^1.1.16",
+        "separator-escape": "0.0.1",
+        "socks": "^2.2.3",
+        "stream-to-pull-stream": "^1.7.2"
+      }
+    },
+    "node_modules/multiserver-address": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multiserver-address/-/multiserver-address-1.0.1.tgz",
+      "integrity": "sha512-IfZMAGs9onCLkYNSnNBri3JxuvhQYllMyh3W9ry86iEDcfW9uPVsHTHDsjDxQtL+dPq3byshmA+Y4LN2wLHwNw==",
+      "dependencies": {
+        "nearley": "^2.15.1"
+      }
+    },
+    "node_modules/multiserver-scopes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/multiserver-scopes/-/multiserver-scopes-1.0.0.tgz",
+      "integrity": "sha512-D3q4IujGRUIKETfR5s0kRtvXTjAMhyl7rtLEMXtvkg0lJPJyS5KYsAULFFy+dYv/+RC642aR1zo/RKNp6sdtQg==",
+      "dependencies": {
+        "non-private-ip": "^1.4.4"
+      }
+    },
+    "node_modules/mutexify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.3.1.tgz",
+      "integrity": "sha512-nU7mOEuaXiQIB/EgTIjYZJ7g8KqMm2D8l4qp+DqA4jxWOb/tnb1KEoqp+tlbdQIDIAiC1i7j7X/3yHDFXLxr9g=="
+    },
+    "node_modules/muxrpc": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.5.2.tgz",
+      "integrity": "sha512-fgYhBfzevyUbwsB8YBlrnmzZOGxWv6OiAUNKQYwPLqbophsZ+GT8STKrCVHCYNjUx6btxFA5+BJPUCFMecyaSA==",
+      "dependencies": {
+        "explain-error": "^1.0.1",
+        "packet-stream": "~2.0.0",
+        "packet-stream-codec": "^1.1.3",
+        "pull-goodbye": "0.0.2",
+        "pull-stream": "^3.6.10"
+      }
+    },
+    "node_modules/napi-macros": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/non-private-ip": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
+      "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "bin": {
+        "non-private-ip": "bin.js"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+    },
+    "node_modules/object-is": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
+      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/observ": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/observ/-/observ-0.2.0.tgz",
+      "integrity": "sha1-C8ObPin6pfnmyqWQbLg5LfQAqmg="
+    },
+    "node_modules/observ-debounce": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/observ-debounce/-/observ-debounce-1.1.1.tgz",
+      "integrity": "sha1-ME6XyFrdpw7NfwjaRQZ475Dwtwc=",
+      "dependencies": {
+        "observ": "~0.2.0"
+      }
+    },
+    "node_modules/obv": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
+      "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
+    },
+    "node_modules/obz": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/obz/-/obz-1.0.2.tgz",
+      "integrity": "sha512-c+EtVwT2IpXz5we2mR40aPLJ1s0eNOsxYeaYbaHhmsY6kWKo3IRkpwpBU5ck0aHfqfKUUEiKabC6rzsrG/hSHw=="
+    },
+    "node_modules/on-change-network-strict": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/on-change-network-strict/-/on-change-network-strict-1.0.0.tgz",
+      "integrity": "sha512-ldHCpTJWgr5KUJy3/TVoSGNwBUA8BP9UFmd0iQqe4aGaXY4PJyzQPiVBIo8VBSlSoKyaJY3vcpW0hixZb6gPaA=="
+    },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-wakeup": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-wakeup/-/on-wakeup-1.0.1.tgz",
+      "integrity": "sha1-ANedmH3efIEXvudLtJA/b22vpSs="
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/packet-stream": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.5.tgz",
+      "integrity": "sha512-+4S+qBUdqD57ka5MDd6nAYGBPril5eyLpbga2y0kPyYhrKvjb8CYTP9r40WLbSxgT/qEGmvgWOrvQe+FYtCI7w=="
+    },
+    "node_modules/packet-stream-codec": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.3.tgz",
+      "integrity": "sha512-LUL4NK7sz01jdSUdCu3z1LyphCiFdQaFouaEDsAWmJpzS0lbeNfvZoX4bi1Tm1ilzheK5VAoD96QskDCZQr+jA==",
+      "dependencies": {
+        "pull-reader": "^1.2.4",
+        "pull-through": "^1.0.17"
+      },
+      "engines": {
+        "node": ">=5.10.0"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "node_modules/plur": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+      "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polyraf": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/polyraf/-/polyraf-1.1.0.tgz",
+      "integrity": "sha512-wKRyhZQE6AC70nJyMCWbwd/dX4S6UsFz+58qAF8HTpCn6C7pvr63FiH4vR9vT6VrhZrJKuT7A81ea/lIslS0bA==",
+      "dependencies": {
+        "random-access-file": "^2.1.0",
+        "random-access-web": "^2.0.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
+      "dependencies": {
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pretty-quick": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.0.tgz",
+      "integrity": "sha512-DtxIxksaUWCgPFN7E1ZZk4+Aav3CCuRdhrDSFZENb404sYMtuo9Zka823F+Mgeyt8Zt3bUiCjFzzWYE9LYqkmQ==",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "execa": "^4.0.0",
+        "find-up": "^4.1.0",
+        "ignore": "^5.1.4",
+        "mri": "^1.1.5",
+        "multimatch": "^4.0.0"
+      },
+      "bin": {
+        "pretty-quick": "bin/pretty-quick.js"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/private-box": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.3.1.tgz",
+      "integrity": "sha512-abAuk3ZDyQvPLY6MygtwaDTUBIZ0C5wMMuX1jXa0svazV+keTwn7cPobRv4WYA9ctsDUztm/9CYu4y2TPL08xw==",
+      "dependencies": {
+        "chloride": "^2.2.9"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "node_modules/promisify-4loc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promisify-4loc/-/promisify-4loc-1.0.0.tgz",
+      "integrity": "sha512-u/XtndUyqqDXAuhFEgFgkpjHG8IizREoj80j5dL4t41eE9yH0gzFPyOD21/VnikdPJtRziuqf6ryTu1HoTjyog==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/promisify-tuple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promisify-tuple/-/promisify-tuple-1.0.1.tgz",
+      "integrity": "sha512-st4Q1R6oAr8hzt1hj3uCYv87Pc5wtDkoq7ZqxWri2xR3x5Zvx7syH2DR4fgknVhMsZ6GV+kxEmhn2tVnwFMmJw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/promisize": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/promisize/-/promisize-1.1.2.tgz",
+      "integrity": "sha1-m0fiyyrkl+seutwsQZHWTRXJSdE="
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "node_modules/pull-abortable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.0.0.tgz",
+      "integrity": "sha1-cBephMO4NN53usOMELd28i38GEM="
+    },
+    "node_modules/pull-async": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-async/-/pull-async-1.0.0.tgz",
+      "integrity": "sha1-FGs24+BD16ZmtZoUFl/dO+889Ew="
+    },
+    "node_modules/pull-async-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-async-filter/-/pull-async-filter-1.0.0.tgz",
+      "integrity": "sha1-68NhfZ3iRjkIyJ/QFnHHJ1ZNaDE=",
+      "dependencies": {
+        "pull-stream": "^2.26.0"
+      }
+    },
+    "node_modules/pull-async-filter/node_modules/pull-stream": {
+      "version": "2.28.4",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
+      "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
+      "dependencies": {
+        "pull-core": "~1.1.0"
+      }
+    },
+    "node_modules/pull-awaitable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-awaitable/-/pull-awaitable-1.0.0.tgz",
+      "integrity": "sha512-tfufzU9wMd1rM38tcgunaKMUNGXMj1Qms1ygEw+ZerkMmLAwilEtMsyzrDSLhNlnfhSzHXovOarieSNrTD1ovQ==",
+      "dependencies": {
+        "pull-thenable": "~1.0.0"
+      }
+    },
+    "node_modules/pull-box-stream": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
+      "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
+      "dependencies": {
+        "chloride": "^2.2.7",
+        "increment-buffer": "~1.0.0",
+        "pull-reader": "^1.2.5",
+        "pull-stream": "^3.2.3",
+        "pull-through": "^1.0.18",
+        "split-buffer": "~1.0.0"
+      }
+    },
+    "node_modules/pull-cat": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+      "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
+    },
+    "node_modules/pull-cont": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.1.1.tgz",
+      "integrity": "sha1-3x1YDicXV7qay666IN4kIdZg1hg="
+    },
+    "node_modules/pull-core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
+      "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
+    },
+    "node_modules/pull-cursor": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz",
+      "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
+      "dependencies": {
+        "looper": "^4.0.0",
+        "ltgt": "^2.2.0",
+        "pull-stream": "^3.6.0"
+      }
+    },
+    "node_modules/pull-cursor/node_modules/looper": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
+      "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
+    },
+    "node_modules/pull-drain-gently": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-drain-gently/-/pull-drain-gently-1.1.0.tgz",
+      "integrity": "sha512-ZUPsNrn8jkU6Y2B4w8Jz3gXAmjSpb+qn4AQhAL8qTWUHULglH16ANr+6qnfOEa1kUoUGVCQZaORTd2NSQFAnhA==",
+      "dependencies": {
+        "cpu-percentage": "~1.0.3",
+        "pull-pause": "~0.0.2"
+      }
+    },
+    "node_modules/pull-goodbye": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
+      "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
+      "dependencies": {
+        "pull-stream": "~3.5.0"
+      }
+    },
+    "node_modules/pull-goodbye/node_modules/pull-stream": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz",
+      "integrity": "sha1-HuW292/Ts6SaWvtt7VwDIKyzz8c="
+    },
+    "node_modules/pull-handshake": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
+      "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
+      "dependencies": {
+        "pull-cat": "^1.1.9",
+        "pull-pair": "~1.1.0",
+        "pull-pushable": "^2.0.0",
+        "pull-reader": "^1.2.3"
+      }
+    },
+    "node_modules/pull-hash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-hash/-/pull-hash-1.0.0.tgz",
+      "integrity": "sha1-/K1NJQe/LCsyMfZT3Jv7LbTw2Iw="
+    },
+    "node_modules/pull-inactivity": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.3.tgz",
+      "integrity": "sha512-swJ/jwkIN/O1bQCE3iY7Xy9r3gYuJ50MXaxZilw/HIduAy4tJu+vcz2/If0L+xNK7Ku/FfjtVbTpRTe7sf3hmA==",
+      "dependencies": {
+        "pull-abortable": "~4.0.0",
+        "pull-stream": "^3.4.5"
+      }
+    },
+    "node_modules/pull-level": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+      "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
+      "dependencies": {
+        "level-post": "^1.0.7",
+        "pull-cat": "^1.1.9",
+        "pull-live": "^1.0.1",
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.0",
+        "pull-window": "^2.1.4",
+        "stream-to-pull-stream": "^1.7.1"
+      }
+    },
+    "node_modules/pull-live": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+      "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
+      "dependencies": {
+        "pull-cat": "^1.1.9",
+        "pull-stream": "^3.4.0"
+      }
+    },
+    "node_modules/pull-looper": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
+      "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
+      "dependencies": {
+        "looper": "^4.0.0"
+      }
+    },
+    "node_modules/pull-looper/node_modules/looper": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
+      "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
+    },
+    "node_modules/pull-next": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-next/-/pull-next-1.0.1.tgz",
+      "integrity": "sha1-A/TX0Zhy/BEUFh6I227PTGXmHlY="
+    },
+    "node_modules/pull-notify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
+      "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
+      "dependencies": {
+        "pull-pushable": "^2.0.0"
+      }
+    },
+    "node_modules/pull-pair": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
+      "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
+    },
+    "node_modules/pull-paramap": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
+      "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
+      "dependencies": {
+        "looper": "^4.0.0"
+      }
+    },
+    "node_modules/pull-paramap/node_modules/looper": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
+      "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
+    },
+    "node_modules/pull-pause": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/pull-pause/-/pull-pause-0.0.2.tgz",
+      "integrity": "sha1-GdRb6PqmFfpVbxSpb9czRiw3+6M="
+    },
+    "node_modules/pull-ping": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.3.tgz",
+      "integrity": "sha512-nbY4yHnMesJBrvkbhMim4VXUC9k1VCkgrkQu49pf8mxFbmb/U2KQrsuePvSmLjRL+VgkBVRSUXUoOY7DtSvhKw==",
+      "dependencies": {
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.5",
+        "statistics": "^3.3.0"
+      }
+    },
+    "node_modules/pull-pushable": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
+    },
+    "node_modules/pull-rate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz",
+      "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
+      "dependencies": {
+        "pull-stream": "^3.6.0"
+      }
+    },
+    "node_modules/pull-reader": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz",
+      "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
+    },
+    "node_modules/pull-stream": {
+      "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
+      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
+    },
+    "node_modules/pull-thenable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-thenable/-/pull-thenable-1.0.0.tgz",
+      "integrity": "sha512-gio2Yanuj5lcN8X+VXtx6F2iWxnhxfaHSKaSJHUzJMNNboEz48/+udzZFDaya8kAwj3DbuFFt1pbb8m1tIS6PQ==",
+      "dependencies": {
+        "quicktask": "~1.0.0"
+      }
+    },
+    "node_modules/pull-through": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
+      "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
+      "dependencies": {
+        "looper": "~3.0.0"
+      }
+    },
+    "node_modules/pull-window": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+      "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
+      "dependencies": {
+        "looper": "^2.0.0"
+      }
+    },
+    "node_modules/pull-window/node_modules/looper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+      "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
+    },
+    "node_modules/pull-ws": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.2.tgz",
+      "integrity": "sha512-Bn4bcJsSzJGOQl4RBulDhG1FkcbDHSCXteI8Jg5k4X6X5TxVzZzKilWJ1WV2v4OnRXl2eYbtHFGsPl8Cr1xJzw==",
+      "dependencies": {
+        "relative-url": "^1.0.2",
+        "safe-buffer": "^5.1.1",
+        "ws": "^1.1.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/push-stream": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/push-stream/-/push-stream-11.0.0.tgz",
+      "integrity": "sha512-rDVD2f3wOztI/59/fukGLwZkUOC55674hncsSwgKF/yLlkkL594AoWTlkF6SGF0x8O5o1j92ObXk8Cxc1llhYg=="
+    },
+    "node_modules/push-stream-to-pull-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/push-stream-to-pull-stream/-/push-stream-to-pull-stream-1.0.3.tgz",
+      "integrity": "sha512-pdE/OKi/jnp9DqGgNRzLY0oVHffn/8TXJmBPzv+ikdvpkeA0J//l5d7TZk1yWwZj9P0JcOIEVDOuHzhXaeBlmw==",
+      "dependencies": {
+        "pull-looper": "^1.0.0",
+        "push-stream": "^10.0.3"
+      }
+    },
+    "node_modules/push-stream-to-pull-stream/node_modules/push-stream": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/push-stream/-/push-stream-10.1.2.tgz",
+      "integrity": "sha512-wCDN1KkAWOMXsiV0XxH/CggHqOYeXvyn00t9Zjp5RKsLZ2rzg/lLJIMAVxYLyh79T168W3fBYcG5TRRJAlQr6g=="
+    },
+    "node_modules/qr-image": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qr-image/-/qr-image-3.2.0.tgz",
+      "integrity": "sha1-n6gpW+rlDEoUnPn5CaHbRkqGcug="
+    },
+    "node_modules/qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/quicktask": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/quicktask/-/quicktask-1.0.1.tgz",
+      "integrity": "sha512-+jhR01aSsi6Iw9wbYumKusRK72QK1ub2oE0kOnRyMkMdD/rXMMGW/TVl5edjcLjuuIKP1ezkr+xQzUMD5/4JHw=="
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/random-access-chrome-file": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/random-access-chrome-file/-/random-access-chrome-file-1.1.4.tgz",
+      "integrity": "sha512-xZW1BT26g+gl8AF1kC/oXX97jCMVoLIbf6yx4eVMwLgOddGhhkJygimnfERSEmhUKiGs3DTymNao6wf/P23Nkg==",
+      "dependencies": {
+        "random-access-storage": "^1.3.0"
+      }
+    },
+    "node_modules/random-access-file": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.2.0.tgz",
+      "integrity": "sha512-B744003Mj7v3EcuPl9hCiB2Ot4aZjgtU2mV6yFY1THiWU/XfGf1uSadR+SlQdJcwHgAWeG7Lbos0aUqjtj8FQg==",
+      "dependencies": {
+        "mkdirp-classic": "^0.5.2",
+        "random-access-storage": "^1.1.1"
+      }
+    },
+    "node_modules/random-access-idb": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/random-access-idb/-/random-access-idb-1.2.1.tgz",
+      "integrity": "sha512-5rZRPhjgfR222n+dmZtRYhu0CF9dDEwxaS+UgeWursIWPmNirR6BajzOB4wG5I7WAeYZea9HCqYKk/Tin3s9cA==",
+      "dependencies": {
+        "buffer-alloc": "^1.1.0",
+        "buffer-from": "^0.1.1",
+        "inherits": "^2.0.3",
+        "next-tick": "^1.0.0",
+        "once": "^1.4.0",
+        "random-access-storage": "^1.3.0"
+      }
+    },
+    "node_modules/random-access-idb-mutable-file": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/random-access-idb-mutable-file/-/random-access-idb-mutable-file-0.3.0.tgz",
+      "integrity": "sha512-CdVAoFNNDn5uAgYOJ8J3ICSaFzaMOa95XnYcX+taj4jirJuRASiTyQSOGR+Z0K8ZkBGuj0A8ivyeRAWuxRCgQA==",
+      "dependencies": {
+        "buffer": "5.1.0",
+        "random-access-storage": "1.3.0"
+      }
+    },
+    "node_modules/random-access-idb-mutable-file/node_modules/buffer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/random-access-idb-mutable-file/node_modules/random-access-storage": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
+      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
+      "dependencies": {
+        "inherits": "^2.0.3"
+      }
+    },
+    "node_modules/random-access-memory": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.1.2.tgz",
+      "integrity": "sha512-wIfh4OZ9T+FRNf6rbXLvEb4FfSxyZpvGnC5kC7Xi39SyPkRYfeJyR9Xwa13iLbNyoNKNIkTFUE4g9lXFb1ZflA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-options": "^1.0.1",
+        "random-access-storage": "^1.1.1"
+      }
+    },
+    "node_modules/random-access-storage": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.1.tgz",
+      "integrity": "sha512-DbCc2TIzOxPaHF6KCbr8zLtiYOJQQQCBHUVNHV/SckUQobCBB2YkDtbLdxGnPwPNpJfEyMWxDAm36A2xkbxxtw==",
+      "dependencies": {
+        "inherits": "^2.0.3"
+      }
+    },
+    "node_modules/random-access-web": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/random-access-web/-/random-access-web-2.0.3.tgz",
+      "integrity": "sha512-nN3AAgl4/lTOYMk5Qm44SzFsglOmaG2d0Kh0603umh35+rk9QXYLFf0nFJ0GOv9INBsP9iT1lub24r8PjyCtvA==",
+      "dependencies": {
+        "@sammacbeth/random-access-idb-mutable-file": "^0.1.1",
+        "random-access-chrome-file": "^1.1.2",
+        "random-access-idb": "^1.2.1",
+        "random-access-idb-mutable-file": "^0.3.0",
+        "random-access-memory": "^3.1.1",
+        "random-access-storage": "^1.3.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/re-emitter": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
+      "integrity": "sha1-+p4xn/3u6zWycpbvDz03TawvUqc="
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/relative-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
+      "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
+      "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dependencies": {
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
+    },
+    "node_modules/run-series": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
+      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g=="
+    },
+    "node_modules/rwlock": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz",
+      "integrity": "sha1-iI1qd6M1HMGiCSBO8u4XIgk4Ns8="
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/secret-handshake": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.20.tgz",
+      "integrity": "sha512-sDtmZDpibGH2ixj3FOmsC3Z/b08eaB2/KAvy2oSp4qvcGdhatBSfb1RdVpwjQl5c3J83WbBo1HSZ7DBtMu43lA==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "explain-error": "^1.0.4",
+        "pull-box-stream": "^1.0.13",
+        "pull-handshake": "^1.1.1",
+        "pull-stream": "^3.4.5"
+      }
+    },
+    "node_modules/secret-stack": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.3.2.tgz",
+      "integrity": "sha512-D46+4LWwsM1LnO4dg6FM/MfGmMk9uYsIcDElqyNeImBnyUueKi2xz10CHF9iSAtSUGReQDV4SCVUiVrPnaKnsA==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "hoox": "0.0.1",
+        "map-merge": "^1.1.0",
+        "multiserver": "^3.1.0",
+        "muxrpc": "^6.5.2",
+        "pull-inactivity": "~2.1.1",
+        "pull-rate": "^1.0.2",
+        "pull-stream": "^3.4.5",
+        "to-camel-case": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=5.10.0"
+      }
+    },
+    "node_modules/secret-stack-decorators": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/secret-stack-decorators/-/secret-stack-decorators-1.1.0.tgz",
+      "integrity": "sha512-wYl0Mcul/fuEbZwn9tN62c+W4LP2RPus/ilt3wdBNQqfBFSMlDXTLaIsrA4SEElb7JEBH4xzdQbOCnTvYHeWCA=="
+    },
+    "node_modules/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "node_modules/separator-escape": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.1.tgz",
+      "integrity": "sha512-daCzTzZVoowYzjW7x9xMH6zr+lt/zsGxV1rtXaoTnlues7ZDx6Qu0l5W3jCdgnXGE1ONAGL+XPWY+IRDxnJ9EQ=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
+      "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.5.1.tgz",
+      "integrity": "sha512-oZCsJJxapULAYJaEYBSzMcz8m3jqgGrHaGhkmU/o/PQfFWYWxkAaA0UMGImb6s6tEXfKi959X6VJjMMQ3P6TTQ==",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/sodium-browserify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.3.0.tgz",
+      "integrity": "sha512-1KRS6Oew3X13AIZhbmGF0YBdt2pQdafJMfv83OZHWbzxG92YBBnN8HYx/VKmYB4xCe90eidNaDJWBEFw/o3ahw==",
+      "dependencies": {
+        "libsodium-wrappers": "^0.7.4",
+        "sha.js": "2.4.5",
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "tweetnacl": "^0.14.1"
+      }
+    },
+    "node_modules/sodium-browserify-tweetnacl": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.6.tgz",
+      "integrity": "sha512-ZnEI26hdluilpYY28Xc4rc1ALfmEp2TWihkJX6Mdtw0z9RfHfpZJU7P8DoKbN1HcBdU9aJmguFZs7igE8nLJPg==",
+      "dependencies": {
+        "chloride-test": "^1.1.0",
+        "ed2curve": "^0.1.4",
+        "sha.js": "^2.4.8",
+        "tweetnacl": "^1.0.1",
+        "tweetnacl-auth": "^0.3.0"
+      }
+    },
+    "node_modules/sodium-browserify-tweetnacl/node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
+    "node_modules/sodium-browserify-tweetnacl/node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "node_modules/sodium-chloride": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.2.tgz",
+      "integrity": "sha512-8AVzr9VHueXqfzfkzUA0aXe/Q4XG3UTmhlP6Pt+HQc5bbAPIJFo7ZIMh9tvn+99QuiMcyDJdYumegGAczl0N+g=="
+    },
+    "node_modules/sodium-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
+      "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "node-gyp-build": "^4.2.0"
+      }
+    },
+    "node_modules/split": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/split-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
+      "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
+    },
+    "node_modules/ssb-caps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-caps/-/ssb-caps-1.1.0.tgz",
+      "integrity": "sha512-qe3qpvchJ+gnH8M/ge4rpL+7eRbSmsEAzNwHkDdrW06OBcziQ6/KuAdmcR6joxCbNeoAXAZF+inkefgE16okXA=="
+    },
+    "node_modules/ssb-client": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.7.9.tgz",
+      "integrity": "sha512-koVuazgGa+Pz7KHnPTsOFvaKSrE0T38wSO7n6P7ZQp+1BpaoBCI4z8Kq2SvMw521Sz9dK9Rwh2bTakEDRgx84A==",
+      "dependencies": {
+        "explain-error": "^1.0.1",
+        "multicb": "^1.2.1",
+        "multiserver": "^3.1.2",
+        "muxrpc": "^6.4.8",
+        "pull-hash": "^1.0.0",
+        "pull-stream": "^3.6.0",
+        "ssb-config": "^3.2.5",
+        "ssb-keys": "^7.0.13"
+      }
+    },
+    "node_modules/ssb-client/node_modules/ssb-keys": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+      "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.3.0"
+      }
+    },
+    "node_modules/ssb-config": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.4.5.tgz",
+      "integrity": "sha512-DyCrGIsl01GkdHreAkkaDUorV7SAgRSqKn/htg4ZwbvH6g0NAdOi84x/8ehzDuojPev78hbkWjZXgIqi+/Jo0g==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ip": "^1.1.5",
+        "lodash.get": "^4.4.2",
+        "os-homedir": "^1.0.1",
+        "rc": "^1.1.6",
+        "ssb-caps": "^1.0.1",
+        "ssb-keys": "^7.1.4"
+      }
+    },
+    "node_modules/ssb-config/node_modules/ssb-keys": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+      "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.3.0"
+      }
+    },
+    "node_modules/ssb-conn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-2.1.0.tgz",
+      "integrity": "sha512-cs3AVZ0QVvhbLkSuP2LIAoJv/6t5pMtri8aD/F1rmSFarz81RC0nks//uuziH4R2946mH3SHb02G3ExAyzvl1g==",
+      "dependencies": {
+        "debug": "^4.3.0",
+        "has-network2": ">=0.0.3",
+        "ip": "^1.1.5",
+        "on-change-network-strict": "1.0.0",
+        "on-wakeup": "^1.0.1",
+        "pull-notify": "^0.1.1",
+        "pull-pause": "~0.0.2",
+        "pull-ping": "^2.0.3",
+        "pull-stream": "^3.6.14",
+        "secret-stack-decorators": "1.1.0",
+        "ssb-conn-db": "~1.0.1",
+        "ssb-conn-hub": "~1.1.0",
+        "ssb-conn-query": "~1.1.0",
+        "ssb-conn-staging": "~1.0.0",
+        "ssb-ref": "^2.14.3",
+        "ssb-typescript": "^2.2.0",
+        "statistics": "^3.3.0",
+        "ziii": "~1.0.2"
+      }
+    },
+    "node_modules/ssb-conn-db": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-1.0.1.tgz",
+      "integrity": "sha512-lTXhHmJ9La7S+YFotLnvn+4uxX5lP+zDNS3N4zPnDDy/3f1AQI6jxEnRDmbhfWqrAEI2gy7Yu6LcgC5rX+MRDA==",
+      "dependencies": {
+        "atomic-file": "^2.1.1",
+        "debug": "^4.3.1",
+        "multiserver-address": "~1.0.1",
+        "pull-notify": "~0.1.1",
+        "ssb-ref": "~2.13.9"
+      }
+    },
+    "node_modules/ssb-conn-db/node_modules/ssb-ref": {
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
+      "integrity": "sha512-TfatNqLvoP+eW/pMIbCmNcaoDq4R2k8jCtWkwDKx4AtluN/LwtyP931d5Mh+2gmzA04W7kxkr6f5ENGgdadMYg==",
+      "dependencies": {
+        "ip": "^1.1.3",
+        "is-canonical-base64": "^1.1.1",
+        "is-valid-domain": "~0.0.1",
+        "multiserver-address": "^1.0.1"
+      }
+    },
+    "node_modules/ssb-conn-hub": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-1.1.0.tgz",
+      "integrity": "sha512-l/PVhYdO1ZrTfWHXvbDKNQaSXiEroiYbXZsAPQiYHRS4TAzrBPhI5uuFp69s3xzKKCVJJDkPhUIWBwZF6SCDgg==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "ip": "^1.1.5",
+        "multiserver": "^3.7.0",
+        "multiserver-address": "~1.0.1",
+        "promisify-tuple": "^1.0.1",
+        "pull-cat": "~1.1.11",
+        "pull-notify": "~0.1.1",
+        "pull-stream": "^3.6.14",
+        "ssb-ref": "^2.14.3"
+      }
+    },
+    "node_modules/ssb-conn-query": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-1.1.0.tgz",
+      "integrity": "sha512-ynSlzwrtAPwQTOsZ74DmM90zRRCy6fI3kaePqKbSI4TVRUDh6zTn83lTYP56PiAr2PPNMB0ICIVLCstY4W70zg==",
+      "dependencies": {
+        "ssb-conn-db": "~1.0.1",
+        "ssb-conn-hub": "~1.1.0",
+        "ssb-conn-staging": "~1.0.0"
+      }
+    },
+    "node_modules/ssb-conn-staging": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-staging/-/ssb-conn-staging-1.0.0.tgz",
+      "integrity": "sha512-NOy1qZoBkhH0XNzLteaaKKePXigEJSCntD4RPRU6vWLMlQ10+SzlIz4TWKgvEVx0LfCe6tEx/vhQf6vBWO/Ylw==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "multiserver-address": "~1.0.1",
+        "pull-cat": "~1.1.11",
+        "pull-notify": "~0.1.1",
+        "pull-stream": "^3.6.9"
+      }
+    },
+    "node_modules/ssb-db2": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/ssb-db2/-/ssb-db2-1.18.5.tgz",
+      "integrity": "sha512-F/5LpySJuANUBPNemx64gdyd6OFER9cBjecS/cBV76/xGcHkC+H3UEiingrZfw7C2r4FHux+E5ZdSrZMCZ7uhw==",
+      "dependencies": {
+        "async-append-only-log": "^3.0.7",
+        "atomically-universal": "^0.1.1",
+        "binary-search-bounds": "^2.0.4",
+        "bipf": "~1.4.0",
+        "debug": "~4.3.1",
+        "fastintcompression": "0.0.4",
+        "flumecodec": "0.0.1",
+        "flumelog-offset": "3.4.4",
+        "hoox": "0.0.1",
+        "jitdb": "^2.3.2",
+        "level": "^6.0.1",
+        "level-codec": "^9.0.2",
+        "lodash.debounce": "^4.0.8",
+        "mkdirp": "^1.0.4",
+        "obz": "^1.0.3",
+        "p-defer": "^3.0.0",
+        "prettier": "^2.1.2",
+        "pretty-quick": "^3.1.0",
+        "promisify-4loc": "1.0.0",
+        "pull-async-filter": "^1.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-cont": "^0.1.1",
+        "pull-drain-gently": "^1.1.0",
+        "pull-level": "^2.0.4",
+        "pull-stream": "^3.6.14",
+        "push-stream": "^11.0.0",
+        "rimraf": "^3.0.2",
+        "ssb-keys": "^8.0.0",
+        "ssb-ref": "^2.14.3",
+        "ssb-sort": "^1.1.3",
+        "ssb-validate": "^4.1.3",
+        "too-hot": "^1.0.0",
+        "typedarray-to-buffer": "^4.0.0"
+      }
+    },
+    "node_modules/ssb-db2/node_modules/flumecodec": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
+      "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
+      "dependencies": {
+        "level-codec": "^6.2.0"
+      }
+    },
+    "node_modules/ssb-db2/node_modules/flumecodec/node_modules/level-codec": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
+      "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+    },
+    "node_modules/ssb-db2/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ssb-db2/node_modules/obz": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/obz/-/obz-1.0.3.tgz",
+      "integrity": "sha512-rH3U4eLHsV+OgkOS29ULiC9JLspwMCyCIH/+BglLPXDxQs13IK8AGD+nVmkGXqGN5JefZu85YhfIi05CsOKWPw=="
+    },
+    "node_modules/ssb-keys": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.1.0.tgz",
+      "integrity": "sha512-RC2gFMptimj2QZZESOViKVhzqgXCnfW3IqUeKLQ/E8nnTdODuCVa3soLYu4KUF8nGIzFIfdKq7L2Teg32kD85w==",
+      "dependencies": {
+        "chloride": "~2.4.1",
+        "mkdirp": "~0.5.0",
+        "private-box": "~0.3.0"
+      },
+      "engines": {
+        "node": ">=5.10.0"
+      }
+    },
+    "node_modules/ssb-keys/node_modules/chloride": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.1.tgz",
+      "integrity": "sha512-ZiID87W2o2llvuF4C7Fvt9GJisazSdMsSkjAq4WaMed9zn77nlkcy08ZfrPtOGAXyaxTDj0VjnuyD97EdJLz3g==",
+      "dependencies": {
+        "sodium-browserify": "^1.2.7",
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "sodium-chloride": "^1.1.2",
+        "sodium-native": "^3.0.0"
+      }
+    },
+    "node_modules/ssb-logging": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-logging/-/ssb-logging-1.0.0.tgz",
+      "integrity": "sha512-6apTG47+VgLAD3MYkpRTbO27DMDh0YLJIvWfcJUEo5FdrjnLsqDl1kkzQ4B5MbH08z5Vklx5907t4by9rhlROQ==",
+      "dependencies": {
+        "bash-color": "0.0.4"
+      }
+    },
+    "node_modules/ssb-master": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ssb-master/-/ssb-master-1.0.3.tgz",
+      "integrity": "sha512-N1Cxm9WscGD9VEZrWbF2amyQai2U2g9gtq57W5zTqbhlQTLUUvl84U9A6fg6GPkECnUXadulnTw+mMYVkLLHjQ=="
+    },
+    "node_modules/ssb-ref": {
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.14.3.tgz",
+      "integrity": "sha512-XhzVmezsUJLlKxTfWlicxhiPRTEYHfJLskYQNRSnw4USqgo9LVx53+MJAhdZOYpZTW2jINR0TeetWs9M27gcbA==",
+      "dependencies": {
+        "ip": "^1.1.3",
+        "is-canonical-base64": "^1.1.1",
+        "is-valid-domain": "~0.0.1",
+        "multiserver-address": "^1.0.1"
+      }
+    },
+    "node_modules/ssb-replicate": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ssb-replicate/-/ssb-replicate-1.3.2.tgz",
+      "integrity": "sha512-r/34OHn5wDkVUu0UNdKdPjmd3cPDmgknA5nK+gXBZj9ugSDwmdDsfEUavGtA7hlO+He1pC4EXtBa14dqgTqJCg==",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "observ-debounce": "^1.1.1",
+        "obv": "0.0.1",
+        "pull-cat": "^1.1.11",
+        "pull-next": "^1.0.1",
+        "pull-notify": "^0.1.1",
+        "pull-paramap": "^1.2.2",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.9",
+        "ssb-ref": "^2.13.9"
+      }
+    },
+    "node_modules/ssb-room": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ssb-room/-/ssb-room-1.3.0.tgz",
+      "integrity": "sha512-2sYuHgV6fLKWNUjSF0ARcTtFL0C+YpL474M7CGOjC+fJWZ5vg7kcZR/7P3wNyfnqI3Jx2tAGVULF/mjsBmCvaA==",
+      "dependencies": {
+        "body-parser": "^1.16.0",
+        "debug": "~4.1.1",
+        "ejs": "^2.5.5",
+        "express": "^4.16.0",
+        "pull-cat": "~1.1.11",
+        "pull-notify": "0.1.1",
+        "pull-pair": "~1.1.0",
+        "pull-stream": "~3.6.14",
+        "qr-image": "^3.2.0",
+        "secret-stack": "6.3.0",
+        "ssb-caps": "~1.1.0",
+        "ssb-client": "~4.7.8",
+        "ssb-config": "~3.3.2",
+        "ssb-conn": ">=0.11.0",
+        "ssb-logging": "~1.0.0",
+        "ssb-master": "~1.0.3",
+        "ssb-ref": "~2.13.9"
+      },
+      "bin": {
+        "ssb-room": "bin.js"
+      }
+    },
+    "node_modules/ssb-room-client": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/ssb-room-client/-/ssb-room-client-0.10.0.tgz",
+      "integrity": "sha512-eve6uJBktZuo/b09z4BXwu8dmmsjB5iXmUsn2adUs7hU591FHP4ZXpLuYDfHL4tGB8m4OaEnHf61gQZwNHuEnQ==",
+      "dependencies": {
+        "@minireq/browser": "^2.0.0",
+        "@minireq/node": "^2.0.0",
+        "debug": "^4.3.1",
+        "pull-pair": "^1.1.0",
+        "pull-stream": "^3.6.14",
+        "ssb-conn-hub": ">=0.2.0",
+        "ssb-conn-staging": ">=0.1.0",
+        "ssb-keys": ">=8.1.0",
+        "ssb-ref": "^2.14.3",
+        "ssb-typescript": "^2.2.0"
+      }
+    },
+    "node_modules/ssb-room/node_modules/debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/ssb-room/node_modules/secret-stack": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.3.0.tgz",
+      "integrity": "sha512-abIfcP1tlJ3gbfgAkp6mgqEc7M70GvXVTyE//iHDXMQz21zQxOD5WcWAiMg1Lgw5FgLfHM1WF+c8PqFNNE3WOg==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "hoox": "0.0.1",
+        "ip": "^1.1.5",
+        "map-merge": "^1.1.0",
+        "multiserver": "^3.1.0",
+        "muxrpc": "^6.4.0",
+        "non-private-ip": "^1.4.3",
+        "pull-inactivity": "~2.1.1",
+        "pull-rate": "^1.0.2",
+        "pull-stream": "^3.4.5",
+        "stream-to-pull-stream": "^1.6.1",
+        "to-camel-case": "^1.0.0"
+      }
+    },
+    "node_modules/ssb-room/node_modules/ssb-config": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.3.3.tgz",
+      "integrity": "sha512-5dcFuYrUqyELNHzX3fOcgF/SRdjVWjkXxgq5+D+bt7KUy1YCCAEiB1VkQfhwWeDblYQCaXSE6rhuWO9JMTkJSg==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "lodash.get": "^4.4.2",
+        "non-private-ip": "^1.4.4",
+        "os-homedir": "^1.0.1",
+        "rc": "^1.1.6",
+        "ssb-caps": "^1.0.1",
+        "ssb-keys": "^7.1.4"
+      }
+    },
+    "node_modules/ssb-room/node_modules/ssb-keys": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+      "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.3.0"
+      }
+    },
+    "node_modules/ssb-room/node_modules/ssb-ref": {
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
+      "integrity": "sha512-TfatNqLvoP+eW/pMIbCmNcaoDq4R2k8jCtWkwDKx4AtluN/LwtyP931d5Mh+2gmzA04W7kxkr6f5ENGgdadMYg==",
+      "dependencies": {
+        "ip": "^1.1.3",
+        "is-canonical-base64": "^1.1.1",
+        "is-valid-domain": "~0.0.1",
+        "multiserver-address": "^1.0.1"
+      }
+    },
+    "node_modules/ssb-sort": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-1.1.3.tgz",
+      "integrity": "sha512-oPsF8lGgcHcIb4F1GddV3CbZTJZ0OzxI9fHXH0Zc7ZjqjFlYdqMDxFSuvqJnmtDydJcswyGANiziP1ghd69jOw==",
+      "dependencies": {
+        "ssb-ref": "^2.3.0"
+      }
+    },
+    "node_modules/ssb-typescript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ssb-typescript/-/ssb-typescript-2.2.0.tgz",
+      "integrity": "sha512-2xdkB0FyJqjOkmv7r7SOTRP934r2Kz/bHPZlUFk5qStDVekMuTeeOkP+czTXHTgp0GYYKIQmq2ChZroz1C8AJA=="
+    },
+    "node_modules/ssb-validate": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-4.1.3.tgz",
+      "integrity": "sha512-g7tOs4nCwHk+G/FZ1N2RmaCkaTNS9hoh/BBP12EH8Jf1PWlkOJtTCak78FHjSTAGFCq/i8Y1ZFQXPNKSK7p3wg==",
+      "dependencies": {
+        "is-canonical-base64": "^1.1.1",
+        "monotonic-timestamp": "0.0.9",
+        "ssb-keys": "^7.0.7",
+        "ssb-ref": "^2.6.2"
+      }
+    },
+    "node_modules/ssb-validate/node_modules/ssb-keys": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+      "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.3.0"
+      }
+    },
+    "node_modules/statistics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/statistics/-/statistics-3.3.0.tgz",
+      "integrity": "sha1-7HtHUP8DqySmTdmzV6eDFr6teKo="
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/stream-to-pull-stream": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+      "dependencies": {
+        "looper": "^3.0.0",
+        "pull-stream": "^3.2.3"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.4.tgz",
+      "integrity": "sha512-hWCk/iqf7lp0/AgTF7/ddO1IWtSNPASjlzCicV5irAVdE1grjsneK26YG6xACMBEdCvO8fUST0UzDMh/2Qy+9Q==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap-out": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-2.1.0.tgz",
+      "integrity": "sha512-LJE+TBoVbOWhwdz4+FQk40nmbIuxJLqaGvj3WauQw3NYYU5TdjoV3C0x/yq37YAvVyi+oeBXmWnxWSjJ7IEyUw==",
+      "dependencies": {
+        "re-emitter": "1.1.3",
+        "readable-stream": "2.2.9",
+        "split": "1.0.0",
+        "trim": "0.0.1"
+      },
+      "bin": {
+        "tap-out": "bin/cmd.js"
+      }
+    },
+    "node_modules/tap-out/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/tap-out/node_modules/readable-stream": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+      "dependencies": {
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/tap-out/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/tap-out/node_modules/string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tap-spec": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-5.0.0.tgz",
+      "integrity": "sha512-zMDVJiE5I6Y4XGjlueGXJIX2YIkbDN44broZlnypT38Hj/czfOXrszHNNJBF/DXR8n+x6gbfSx68x04kIEHdrw==",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "duplexer": "^0.1.1",
+        "figures": "^1.4.0",
+        "lodash": "^4.17.10",
+        "pretty-ms": "^2.1.0",
+        "repeat-string": "^1.5.2",
+        "tap-out": "^2.1.0",
+        "through2": "^2.0.0"
+      },
+      "bin": {
+        "tap-spec": "bin/cmd.js",
+        "tspec": "bin/cmd.js"
+      }
+    },
+    "node_modules/tap-spec/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap-spec/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap-spec/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/tape": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.2.2.tgz",
+      "integrity": "sha512-grXrzPC1ly2kyTMKdqxh5GiLpb0BpNctCuecTB0psHX4Gu0nc+uxWR4xKjTh/4CfQlH4zhvTM2/EXmHXp6v/uA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "deep-equal": "^2.0.5",
+        "defined": "^1.0.0",
+        "dotignore": "^0.1.2",
+        "for-each": "^0.3.3",
+        "glob": "^7.1.6",
+        "has": "^1.0.3",
+        "inherits": "^2.0.4",
+        "is-regex": "^1.1.2",
+        "minimist": "^1.2.5",
+        "object-inspect": "^1.9.0",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.2",
+        "resolve": "^2.0.0-next.3",
+        "resumer": "^0.0.0",
+        "string.prototype.trim": "^1.2.4",
+        "through": "^2.3.8"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/tape/node_modules/deep-equal": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
+      "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "es-get-iterator": "^1.1.1",
+        "get-intrinsic": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/tape/node_modules/is-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/tape/node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/through2/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/to-camel-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
+      "integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
+      "dependencies": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "node_modules/to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
+    },
+    "node_modules/to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+      "dependencies": {
+        "to-no-case": "^1.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/too-hot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/too-hot/-/too-hot-1.0.0.tgz",
+      "integrity": "sha512-RqtHvVffaf+ORMlpFjEWh3czDy6Q5wFfdGq9JXVBXu2L8/ssjDTnong8f1+I2xWGlKslXUkHU7m1HBj6MyoLqw==",
+      "dependencies": {
+        "cpu-percentage": "~1.0.3"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "node_modules/trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "node_modules/tweetnacl-auth": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
+      "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
+      "dependencies": {
+        "tweetnacl": "0.x.x"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ=="
+    },
+    "node_modules/typedfastbitset": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/typedfastbitset/-/typedfastbitset-0.2.1.tgz",
+      "integrity": "sha512-B2B+wo5gC7VRAqcFEiUCjS6CJ1vmeYZ7uzY3Jsu6UNStHiF+W0vkhZAmQaj5m9sC2KVrpyHGRzGuhz3M6+n/8A=="
+    },
+    "node_modules/uint48be": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-2.0.1.tgz",
+      "integrity": "sha512-LQvWofTo3RCz+XaQR3VNch+dDFwpIvWr/98imhQne++vFhpQP16YAC/a8w9N00Heqqra00ACjHT18cgvn5H+bg=="
+    },
+    "node_modules/ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
+      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.0",
+        "has-symbols": "^1.0.0",
+        "which-boxed-primitive": "^1.0.1"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/ws": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "dependencies": {
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/ziii": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ziii/-/ziii-1.0.2.tgz",
+      "integrity": "sha512-q1FogtBIchy1W0fkxUpe6A4n4WUvAM+hAHN1J6LjBNCV42ZegeC5JSz0mcNv4qxnI0V4cL4FNeEhPMm97Ed0kA=="
+    }
+  },
   "dependencies": {
+    "@minireq/browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@minireq/browser/-/browser-2.0.0.tgz",
+      "integrity": "sha512-0A6KOXLL+EQlFaLjNKvH2bRxy8fKPH/DNBy7IXq36LdSPubbzmJ8qoPTxTCfFsTVSFhozEhn48u8QjoyEQq2BQ==",
+      "requires": {
+        "@minireq/common": "^2.0.0"
+      }
+    },
+    "@minireq/common": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@minireq/common/-/common-2.0.0.tgz",
+      "integrity": "sha512-dVza/V5g0uURv2rnJ2vNchb8WlrOVlkLHscfO74poiFB4nPqnYz+8bLVY2uwH9W/1SAG73kEZPOsGibBnn7rBg=="
+    },
+    "@minireq/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@minireq/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-qaXdz7sQb45Q8r2MGUadP1Wj8cjQ+srG0FhXGiv+5HoD1Mdl3hEqRy1OFjgiAY8KCgt4tIV8W5heYZ6H94A42w==",
+      "requires": {
+        "@minireq/common": "^2.0.0"
+      }
+    },
     "@sammacbeth/random-access-idb-mutable-file": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@sammacbeth/random-access-idb-mutable-file/-/random-access-idb-mutable-file-0.1.1.tgz",
@@ -2923,10 +6892,12 @@
       }
     },
     "ssb-room-client": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ssb-room-client/-/ssb-room-client-0.4.0.tgz",
-      "integrity": "sha512-qQSOYH2qQ+rYZjBx/cgluzMpOkfN/TalctVI6/hhdukvloxY0FbCbyqvJCEbxXWLreL6LGGz1N4UESOcimTECg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/ssb-room-client/-/ssb-room-client-0.10.0.tgz",
+      "integrity": "sha512-eve6uJBktZuo/b09z4BXwu8dmmsjB5iXmUsn2adUs7hU591FHP4ZXpLuYDfHL4tGB8m4OaEnHf61gQZwNHuEnQ==",
       "requires": {
+        "@minireq/browser": "^2.0.0",
+        "@minireq/node": "^2.0.0",
         "debug": "^4.3.1",
         "pull-pair": "^1.1.0",
         "pull-stream": "^3.6.14",
@@ -2992,6 +6963,14 @@
         "pull-stream": "^3.2.3"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string.prototype.trim": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.4.tgz",
@@ -3018,14 +6997,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {

--- a/muxrpc/test/nodejs/package.json
+++ b/muxrpc/test/nodejs/package.json
@@ -18,7 +18,7 @@
     "ssb-keys": "^8.1.0",
     "ssb-replicate": "^1.3.2",
     "ssb-room": "^1.3.0",
-    "ssb-room-client": "^0.4.0",
+    "ssb-room-client": "^0.10.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.2.2"
   }

--- a/roomdb/interface.go
+++ b/roomdb/interface.go
@@ -20,6 +20,8 @@ import (
 type RoomConfig interface {
 	GetPrivacyMode(context.Context) (PrivacyMode, error)
 	SetPrivacyMode(context.Context, PrivacyMode) error
+	GetDefaultLanguage(context.Context) (string, error)
+	SetDefaultLanguage(context.Context, string) error
 }
 
 // AuthFallbackService allows password authentication which might be helpful for scenarios

--- a/roomdb/mockdb/roomconfig.go
+++ b/roomdb/mockdb/roomconfig.go
@@ -9,6 +9,19 @@ import (
 )
 
 type FakeRoomConfig struct {
+	GetDefaultLanguageStub        func(context.Context) (string, error)
+	getDefaultLanguageMutex       sync.RWMutex
+	getDefaultLanguageArgsForCall []struct {
+		arg1 context.Context
+	}
+	getDefaultLanguageReturns struct {
+		result1 string
+		result2 error
+	}
+	getDefaultLanguageReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	GetPrivacyModeStub        func(context.Context) (roomdb.PrivacyMode, error)
 	getPrivacyModeMutex       sync.RWMutex
 	getPrivacyModeArgsForCall []struct {
@@ -21,6 +34,18 @@ type FakeRoomConfig struct {
 	getPrivacyModeReturnsOnCall map[int]struct {
 		result1 roomdb.PrivacyMode
 		result2 error
+	}
+	SetDefaultLanguageStub        func(context.Context, string) error
+	setDefaultLanguageMutex       sync.RWMutex
+	setDefaultLanguageArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	setDefaultLanguageReturns struct {
+		result1 error
+	}
+	setDefaultLanguageReturnsOnCall map[int]struct {
+		result1 error
 	}
 	SetPrivacyModeStub        func(context.Context, roomdb.PrivacyMode) error
 	setPrivacyModeMutex       sync.RWMutex
@@ -36,6 +61,70 @@ type FakeRoomConfig struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeRoomConfig) GetDefaultLanguage(arg1 context.Context) (string, error) {
+	fake.getDefaultLanguageMutex.Lock()
+	ret, specificReturn := fake.getDefaultLanguageReturnsOnCall[len(fake.getDefaultLanguageArgsForCall)]
+	fake.getDefaultLanguageArgsForCall = append(fake.getDefaultLanguageArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.GetDefaultLanguageStub
+	fakeReturns := fake.getDefaultLanguageReturns
+	fake.recordInvocation("GetDefaultLanguage", []interface{}{arg1})
+	fake.getDefaultLanguageMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeRoomConfig) GetDefaultLanguageCallCount() int {
+	fake.getDefaultLanguageMutex.RLock()
+	defer fake.getDefaultLanguageMutex.RUnlock()
+	return len(fake.getDefaultLanguageArgsForCall)
+}
+
+func (fake *FakeRoomConfig) GetDefaultLanguageCalls(stub func(context.Context) (string, error)) {
+	fake.getDefaultLanguageMutex.Lock()
+	defer fake.getDefaultLanguageMutex.Unlock()
+	fake.GetDefaultLanguageStub = stub
+}
+
+func (fake *FakeRoomConfig) GetDefaultLanguageArgsForCall(i int) context.Context {
+	fake.getDefaultLanguageMutex.RLock()
+	defer fake.getDefaultLanguageMutex.RUnlock()
+	argsForCall := fake.getDefaultLanguageArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRoomConfig) GetDefaultLanguageReturns(result1 string, result2 error) {
+	fake.getDefaultLanguageMutex.Lock()
+	defer fake.getDefaultLanguageMutex.Unlock()
+	fake.GetDefaultLanguageStub = nil
+	fake.getDefaultLanguageReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRoomConfig) GetDefaultLanguageReturnsOnCall(i int, result1 string, result2 error) {
+	fake.getDefaultLanguageMutex.Lock()
+	defer fake.getDefaultLanguageMutex.Unlock()
+	fake.GetDefaultLanguageStub = nil
+	if fake.getDefaultLanguageReturnsOnCall == nil {
+		fake.getDefaultLanguageReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.getDefaultLanguageReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeRoomConfig) GetPrivacyMode(arg1 context.Context) (roomdb.PrivacyMode, error) {
@@ -100,6 +189,68 @@ func (fake *FakeRoomConfig) GetPrivacyModeReturnsOnCall(i int, result1 roomdb.Pr
 		result1 roomdb.PrivacyMode
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeRoomConfig) SetDefaultLanguage(arg1 context.Context, arg2 string) error {
+	fake.setDefaultLanguageMutex.Lock()
+	ret, specificReturn := fake.setDefaultLanguageReturnsOnCall[len(fake.setDefaultLanguageArgsForCall)]
+	fake.setDefaultLanguageArgsForCall = append(fake.setDefaultLanguageArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.SetDefaultLanguageStub
+	fakeReturns := fake.setDefaultLanguageReturns
+	fake.recordInvocation("SetDefaultLanguage", []interface{}{arg1, arg2})
+	fake.setDefaultLanguageMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRoomConfig) SetDefaultLanguageCallCount() int {
+	fake.setDefaultLanguageMutex.RLock()
+	defer fake.setDefaultLanguageMutex.RUnlock()
+	return len(fake.setDefaultLanguageArgsForCall)
+}
+
+func (fake *FakeRoomConfig) SetDefaultLanguageCalls(stub func(context.Context, string) error) {
+	fake.setDefaultLanguageMutex.Lock()
+	defer fake.setDefaultLanguageMutex.Unlock()
+	fake.SetDefaultLanguageStub = stub
+}
+
+func (fake *FakeRoomConfig) SetDefaultLanguageArgsForCall(i int) (context.Context, string) {
+	fake.setDefaultLanguageMutex.RLock()
+	defer fake.setDefaultLanguageMutex.RUnlock()
+	argsForCall := fake.setDefaultLanguageArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeRoomConfig) SetDefaultLanguageReturns(result1 error) {
+	fake.setDefaultLanguageMutex.Lock()
+	defer fake.setDefaultLanguageMutex.Unlock()
+	fake.SetDefaultLanguageStub = nil
+	fake.setDefaultLanguageReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeRoomConfig) SetDefaultLanguageReturnsOnCall(i int, result1 error) {
+	fake.setDefaultLanguageMutex.Lock()
+	defer fake.setDefaultLanguageMutex.Unlock()
+	fake.SetDefaultLanguageStub = nil
+	if fake.setDefaultLanguageReturnsOnCall == nil {
+		fake.setDefaultLanguageReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setDefaultLanguageReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeRoomConfig) SetPrivacyMode(arg1 context.Context, arg2 roomdb.PrivacyMode) error {
@@ -167,8 +318,12 @@ func (fake *FakeRoomConfig) SetPrivacyModeReturnsOnCall(i int, result1 error) {
 func (fake *FakeRoomConfig) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.getDefaultLanguageMutex.RLock()
+	defer fake.getDefaultLanguageMutex.RUnlock()
 	fake.getPrivacyModeMutex.RLock()
 	defer fake.getPrivacyModeMutex.RUnlock()
+	fake.setDefaultLanguageMutex.RLock()
+	defer fake.setDefaultLanguageMutex.RUnlock()
 	fake.setPrivacyModeMutex.RLock()
 	defer fake.setPrivacyModeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/roomdb/sqlite/migrations/03-config.sql
+++ b/roomdb/sqlite/migrations/03-config.sql
@@ -4,6 +4,7 @@ CREATE TABLE config (
     id integer NOT NULL PRIMARY KEY,
     privacyMode integer NOT NULL,    -- open, community, restricted
     defaultLanguage TEXT NOT NULL,   -- a language tag, e.g. en, sv, de
+    use_subdomain_for_aliases boolean NOT NULL, -- flag to toggle using subdomains (rather than alias routes) for aliases
 
     CHECK (id == 0) -- should only ever store one row
 );
@@ -11,10 +12,11 @@ CREATE TABLE config (
 -- the config table will only ever contain one row: the rooms current settings
 -- we update that row whenever the config changes.
 -- to have something to update, we insert the first and only row at id 0
-INSERT INTO config (id, privacyMode, defaultLanguage) VALUES (
+INSERT INTO config (id, privacyMode, defaultLanguage, use_subdomain_for_aliases) VALUES (
     0,     -- the constant id we will query
     2,     -- community is the default mode unless overridden
-    "en"   -- english is the default language for all installs
+    "en",  -- english is the default language for all installs
+    1      -- use subdomain for aliases
 );
 
 -- +migrate Down

--- a/roomdb/sqlite/migrations/03-config.sql
+++ b/roomdb/sqlite/migrations/03-config.sql
@@ -1,8 +1,9 @@
 -- +migrate Up
--- the configuration settings for this room, currently only privacy modes
+-- the configuration settings for this room, currently privacy mode settings and the default translation for the room
 CREATE TABLE config (
     id integer NOT NULL PRIMARY KEY,
     privacyMode integer NOT NULL,    -- open, community, restricted
+    defaultLanguage TEXT NOT NULL,   -- a language tag, e.g. en, sv, de
 
     CHECK (id == 0) -- should only ever store one row
 );
@@ -10,9 +11,10 @@ CREATE TABLE config (
 -- the config table will only ever contain one row: the rooms current settings
 -- we update that row whenever the config changes.
 -- to have something to update, we insert the first and only row at id 0
-INSERT INTO config (id, privacyMode) VALUES (
-    0,  -- the constant id we will query
-    2   -- community is the default mode unless overridden
+INSERT INTO config (id, privacyMode, defaultLanguage) VALUES (
+    0,     -- the constant id we will query
+    2,     -- community is the default mode unless overridden
+    "en"   -- english is the default language for all installs
 );
 
 -- +migrate Down

--- a/roomdb/sqlite/models/config.go
+++ b/roomdb/sqlite/models/config.go
@@ -23,19 +23,22 @@ import (
 
 // Config is an object representing the database table.
 type Config struct {
-	ID          int64              `boil:"id" json:"id" toml:"id" yaml:"id"`
-	PrivacyMode roomdb.PrivacyMode `boil:"privacyMode" json:"privacyMode" toml:"privacyMode" yaml:"privacyMode"`
+	ID              int64              `boil:"id" json:"id" toml:"id" yaml:"id"`
+	PrivacyMode     roomdb.PrivacyMode `boil:"privacyMode" json:"privacyMode" toml:"privacyMode" yaml:"privacyMode"`
+	DefaultLanguage string             `boil:"defaultLanguage" json:"defaultLanguage" toml:"defaultLanguage" yaml:"defaultLanguage"`
 
 	R *configR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L configL  `boil:"-" json:"-" toml:"-" yaml:"-"`
 }
 
 var ConfigColumns = struct {
-	ID          string
-	PrivacyMode string
+	ID              string
+	PrivacyMode     string
+	DefaultLanguage string
 }{
-	ID:          "id",
-	PrivacyMode: "privacyMode",
+	ID:              "id",
+	PrivacyMode:     "privacyMode",
+	DefaultLanguage: "defaultLanguage",
 }
 
 // Generated where
@@ -62,11 +65,13 @@ func (w whereHelperroomdb_PrivacyMode) GTE(x roomdb.PrivacyMode) qm.QueryMod {
 }
 
 var ConfigWhere = struct {
-	ID          whereHelperint64
-	PrivacyMode whereHelperroomdb_PrivacyMode
+	ID              whereHelperint64
+	PrivacyMode     whereHelperroomdb_PrivacyMode
+	DefaultLanguage whereHelperstring
 }{
-	ID:          whereHelperint64{field: "\"config\".\"id\""},
-	PrivacyMode: whereHelperroomdb_PrivacyMode{field: "\"config\".\"privacyMode\""},
+	ID:              whereHelperint64{field: "\"config\".\"id\""},
+	PrivacyMode:     whereHelperroomdb_PrivacyMode{field: "\"config\".\"privacyMode\""},
+	DefaultLanguage: whereHelperstring{field: "\"config\".\"defaultLanguage\""},
 }
 
 // ConfigRels is where relationship names are stored.
@@ -86,8 +91,8 @@ func (*configR) NewStruct() *configR {
 type configL struct{}
 
 var (
-	configAllColumns            = []string{"id", "privacyMode"}
-	configColumnsWithoutDefault = []string{"privacyMode"}
+	configAllColumns            = []string{"id", "privacyMode", "defaultLanguage"}
+	configColumnsWithoutDefault = []string{"privacyMode", "defaultLanguage"}
 	configColumnsWithDefault    = []string{"id"}
 	configPrimaryKeyColumns     = []string{"id"}
 )

--- a/roomdb/sqlite/models/config.go
+++ b/roomdb/sqlite/models/config.go
@@ -23,22 +23,25 @@ import (
 
 // Config is an object representing the database table.
 type Config struct {
-	ID              int64              `boil:"id" json:"id" toml:"id" yaml:"id"`
-	PrivacyMode     roomdb.PrivacyMode `boil:"privacyMode" json:"privacyMode" toml:"privacyMode" yaml:"privacyMode"`
-	DefaultLanguage string             `boil:"defaultLanguage" json:"defaultLanguage" toml:"defaultLanguage" yaml:"defaultLanguage"`
+	ID                     int64              `boil:"id" json:"id" toml:"id" yaml:"id"`
+	PrivacyMode            roomdb.PrivacyMode `boil:"privacyMode" json:"privacyMode" toml:"privacyMode" yaml:"privacyMode"`
+	DefaultLanguage        string             `boil:"defaultLanguage" json:"defaultLanguage" toml:"defaultLanguage" yaml:"defaultLanguage"`
+	UseSubdomainForAliases bool               `boil:"use_subdomain_for_aliases" json:"use_subdomain_for_aliases" toml:"use_subdomain_for_aliases" yaml:"use_subdomain_for_aliases"`
 
 	R *configR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L configL  `boil:"-" json:"-" toml:"-" yaml:"-"`
 }
 
 var ConfigColumns = struct {
-	ID              string
-	PrivacyMode     string
-	DefaultLanguage string
+	ID                     string
+	PrivacyMode            string
+	DefaultLanguage        string
+	UseSubdomainForAliases string
 }{
-	ID:              "id",
-	PrivacyMode:     "privacyMode",
-	DefaultLanguage: "defaultLanguage",
+	ID:                     "id",
+	PrivacyMode:            "privacyMode",
+	DefaultLanguage:        "defaultLanguage",
+	UseSubdomainForAliases: "use_subdomain_for_aliases",
 }
 
 // Generated where
@@ -64,14 +67,25 @@ func (w whereHelperroomdb_PrivacyMode) GTE(x roomdb.PrivacyMode) qm.QueryMod {
 	return qmhelper.Where(w.field, qmhelper.GTE, x)
 }
 
+type whereHelperbool struct{ field string }
+
+func (w whereHelperbool) EQ(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.EQ, x) }
+func (w whereHelperbool) NEQ(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.NEQ, x) }
+func (w whereHelperbool) LT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.LT, x) }
+func (w whereHelperbool) LTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.LTE, x) }
+func (w whereHelperbool) GT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.GT, x) }
+func (w whereHelperbool) GTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
+
 var ConfigWhere = struct {
-	ID              whereHelperint64
-	PrivacyMode     whereHelperroomdb_PrivacyMode
-	DefaultLanguage whereHelperstring
+	ID                     whereHelperint64
+	PrivacyMode            whereHelperroomdb_PrivacyMode
+	DefaultLanguage        whereHelperstring
+	UseSubdomainForAliases whereHelperbool
 }{
-	ID:              whereHelperint64{field: "\"config\".\"id\""},
-	PrivacyMode:     whereHelperroomdb_PrivacyMode{field: "\"config\".\"privacyMode\""},
-	DefaultLanguage: whereHelperstring{field: "\"config\".\"defaultLanguage\""},
+	ID:                     whereHelperint64{field: "\"config\".\"id\""},
+	PrivacyMode:            whereHelperroomdb_PrivacyMode{field: "\"config\".\"privacyMode\""},
+	DefaultLanguage:        whereHelperstring{field: "\"config\".\"defaultLanguage\""},
+	UseSubdomainForAliases: whereHelperbool{field: "\"config\".\"use_subdomain_for_aliases\""},
 }
 
 // ConfigRels is where relationship names are stored.
@@ -91,8 +105,8 @@ func (*configR) NewStruct() *configR {
 type configL struct{}
 
 var (
-	configAllColumns            = []string{"id", "privacyMode", "defaultLanguage"}
-	configColumnsWithoutDefault = []string{"privacyMode", "defaultLanguage"}
+	configAllColumns            = []string{"id", "privacyMode", "defaultLanguage", "use_subdomain_for_aliases"}
+	configColumnsWithoutDefault = []string{"privacyMode", "defaultLanguage", "use_subdomain_for_aliases"}
 	configColumnsWithDefault    = []string{"id"}
 	configPrimaryKeyColumns     = []string{"id"}
 )

--- a/roomdb/sqlite/models/invites.go
+++ b/roomdb/sqlite/models/invites.go
@@ -48,15 +48,6 @@ var InviteColumns = struct {
 
 // Generated where
 
-type whereHelperbool struct{ field string }
-
-func (w whereHelperbool) EQ(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.EQ, x) }
-func (w whereHelperbool) NEQ(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.NEQ, x) }
-func (w whereHelperbool) LT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.LT, x) }
-func (w whereHelperbool) LTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.LTE, x) }
-func (w whereHelperbool) GT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.GT, x) }
-func (w whereHelperbool) GTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
-
 var InviteWhere = struct {
 	ID          whereHelperint64
 	HashedToken whereHelperstring

--- a/roomdb/sqlite/roomconfig.go
+++ b/roomdb/sqlite/roomconfig.go
@@ -68,7 +68,6 @@ func (c Config) SetPrivacyMode(ctx context.Context, pm roomdb.PrivacyMode) error
 	return nil // alles gut!!
 }
 
-// TODO: use proper language tag from "golang.org/x/text/language"?
 func (c Config) GetDefaultLanguage(ctx context.Context) (string, error) {
 	config, err := models.FindConfig(ctx, c.db, configRowID)
 	if err != nil {

--- a/roomdb/sqlite/roomconfig.go
+++ b/roomdb/sqlite/roomconfig.go
@@ -40,7 +40,6 @@ func (c Config) SetPrivacyMode(ctx context.Context, pm roomdb.PrivacyMode) error
 		return err
 	}
 
-	// cblgh: a walkthrough of this step (again, now that i have some actual context) would be real good :)
 	err = transact(c.db, func(tx *sql.Tx) error {
 		// get the settings row
 		config, err := models.FindConfig(ctx, tx, configRowID)
@@ -57,6 +56,49 @@ func (c Config) SetPrivacyMode(ctx context.Context, pm roomdb.PrivacyMode) error
 		}
 		if rowsAffected == 0 {
 			return fmt.Errorf("setting privacy mode should have update the settings row, instead 0 rows were updated")
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil // alles gut!!
+}
+
+// TODO: use proper language tag from "golang.org/x/text/language"?
+func (c Config) GetDefaultLanguage(ctx context.Context) (string, error) {
+	config, err := models.FindConfig(ctx, c.db, configRowID)
+	if err != nil {
+		return "", err
+	}
+
+	return config.DefaultLanguage, nil
+}
+
+func (c Config) SetDefaultLanguage(ctx context.Context, langTag string) error {
+	if len(langTag) == 0 {
+		return fmt.Errorf("language tag cannot be empty")
+	}
+
+	err := transact(c.db, func(tx *sql.Tx) error {
+		// get the settings row
+		config, err := models.FindConfig(ctx, tx, configRowID)
+		if err != nil {
+			return err
+		}
+
+		// set the new language tag
+		config.DefaultLanguage = langTag
+		// issue update stmt
+		rowsAffected, err := config.Update(ctx, tx, boil.Infer())
+		if err != nil {
+			return err
+		}
+		if rowsAffected == 0 {
+			return fmt.Errorf("setting default language should have update the settings row, instead 0 rows were updated")
 		}
 
 		return nil

--- a/web/handlers/admin/handler.go
+++ b/web/handlers/admin/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ssb-ngi-pointer/go-ssb-room/web"
 	weberrors "github.com/ssb-ngi-pointer/go-ssb-room/web/errors"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/i18n"
 )
 
 // HTMLTemplates define the list of files the template system should load.
@@ -65,6 +66,7 @@ func Handler(
 	r *render.Renderer,
 	roomState *roomstate.Manager,
 	fh *weberrors.FlashHelper,
+	locHelper *i18n.Helper,
 	dbs Databases,
 ) http.Handler {
 	mux := &http.ServeMux{}
@@ -84,11 +86,12 @@ func Handler(
 	var sh = settingsHandler{
 		r:     r,
 		urlTo: urlTo,
-
 		db: dbs.Config,
+		loc: locHelper,
 	}
 	mux.HandleFunc("/settings", r.HTML("admin/settings.tmpl", sh.overview))
 	mux.HandleFunc("/settings/set-privacy", sh.setPrivacy)
+	mux.HandleFunc("/settings/set-language", sh.setLanguage)
 
 	mux.HandleFunc("/menu", r.HTML("admin/menu.tmpl", func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
 		return map[string]interface{}{}, nil

--- a/web/handlers/admin/handler.go
+++ b/web/handlers/admin/handler.go
@@ -21,8 +21,8 @@ import (
 	"github.com/ssb-ngi-pointer/go-ssb-room/roomstate"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web"
 	weberrors "github.com/ssb-ngi-pointer/go-ssb-room/web/errors"
-	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/i18n"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
 )
 
 // HTMLTemplates define the list of files the template system should load.
@@ -86,8 +86,8 @@ func Handler(
 	var sh = settingsHandler{
 		r:     r,
 		urlTo: urlTo,
-		db: dbs.Config,
-		loc: locHelper,
+		db:    dbs.Config,
+		loc:   locHelper,
 	}
 	mux.HandleFunc("/settings", r.HTML("admin/settings.tmpl", sh.overview))
 	mux.HandleFunc("/settings/set-privacy", sh.setPrivacy)

--- a/web/handlers/admin/set_language_test.go
+++ b/web/handlers/admin/set_language_test.go
@@ -2,17 +2,16 @@ package admin
 
 import (
 	"net/http"
-  "strings"
+	"strings"
 	"testing"
 
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
 	"github.com/stretchr/testify/assert"
 )
 
-
 /* can't test English atm due to web/i18n/i18ntesting/testing.go:justTheKeys, which generates translations that are just
 * translationLabel = "translationLabel"
-*/
+ */
 // func TestLanguageSetDefaultLanguageEnglish(t *testing.T) {
 // 	ts := newSession(t)
 // 	a := assert.New(t)
@@ -40,6 +39,6 @@ func TestLanguageSetDefaultLanguage(t *testing.T) {
 	a.Equal(http.StatusOK, resp.Code, "Wrong HTTP status code")
 
 	summaryElement := html.Find("#language-summary")
-  summaryText := strings.TrimSpace(summaryElement.Text())
-  a.Equal("Deutsch", summaryText, "summary language should display german translation of language name")
+	summaryText := strings.TrimSpace(summaryElement.Text())
+	a.Equal("Deutsch", summaryText, "summary language should display german translation of language name")
 }

--- a/web/handlers/admin/set_language_test.go
+++ b/web/handlers/admin/set_language_test.go
@@ -1,0 +1,45 @@
+package admin
+
+import (
+	"net/http"
+  "strings"
+	"testing"
+
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
+	"github.com/stretchr/testify/assert"
+)
+
+
+/* can't test English atm due to web/i18n/i18ntesting/testing.go:justTheKeys, which generates translations that are just
+* translationLabel = "translationLabel"
+*/
+// func TestLanguageSetDefaultLanguageEnglish(t *testing.T) {
+// 	ts := newSession(t)
+// 	a := assert.New(t)
+//
+// 	ts.ConfigDB.GetDefaultLanguageReturns("en", nil)
+//
+// 	u := ts.URLTo(router.AdminSettings)
+// 	html, resp := ts.Client.GetHTML(u)
+// 	a.Equal(http.StatusOK, resp.Code, "Wrong HTTP status code")
+//
+//   fmt.Println(html.Html())
+// 	summaryElement := html.Find("#language-summary")
+//   summaryText := strings.TrimSpace(summaryElement.Text())
+//   a.Equal("English", summaryText, "summary language should display english translation of language name")
+// }
+
+func TestLanguageSetDefaultLanguage(t *testing.T) {
+	ts := newSession(t)
+	a := assert.New(t)
+
+	ts.ConfigDB.GetDefaultLanguageReturns("de", nil)
+
+	u := ts.URLTo(router.AdminSettings)
+	html, resp := ts.Client.GetHTML(u)
+	a.Equal(http.StatusOK, resp.Code, "Wrong HTTP status code")
+
+	summaryElement := html.Find("#language-summary")
+  summaryText := strings.TrimSpace(summaryElement.Text())
+  a.Equal("Deutsch", summaryText, "summary language should display german translation of language name")
+}

--- a/web/handlers/admin/settings.go
+++ b/web/handlers/admin/settings.go
@@ -115,13 +115,13 @@ func (h settingsHandler) getMember(w http.ResponseWriter, req *http.Request) *ro
 
 func (h settingsHandler) verifyPostRequirements(w http.ResponseWriter, req *http.Request) bool {
 	if req.Method != "POST" {
-		// TODO: proper error type
-		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request"))
+		err := weberrors.ErrBadRequest{Where: "HTTP Method", Details: fmt.Errorf("expected POST not %s", req.Method)}
+		h.r.Error(w, req, http.StatusBadRequest, err)
 		return false
 	}
 	if err := req.ParseForm(); err != nil {
-		// TODO: proper error type
-		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request: %w", err))
+		err = weberrors.ErrBadRequest{Where: "Form data", Details: err}
+		h.r.Error(w, req, http.StatusBadRequest, err)
 		return false
 	}
 	return true

--- a/web/handlers/admin/settings.go
+++ b/web/handlers/admin/settings.go
@@ -13,56 +13,68 @@ import (
 	"github.com/ssb-ngi-pointer/go-ssb-room/roomdb"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web"
 	weberrors "github.com/ssb-ngi-pointer/go-ssb-room/web/errors"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/i18n"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/members"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
 )
 
 type settingsHandler struct {
-	r     *render.Renderer
+	r   *render.Renderer
 	urlTo web.URLMaker
-
-	db roomdb.RoomConfig
+	db  roomdb.RoomConfig
+	loc *i18n.Helper
 }
 
 func (h settingsHandler) overview(w http.ResponseWriter, req *http.Request) (interface{}, error) {
 	privacyModes := []roomdb.PrivacyMode{roomdb.ModeOpen, roomdb.ModeCommunity, roomdb.ModeRestricted}
+
 	currentMode, err := h.db.GetPrivacyMode(req.Context())
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve current privacy mode: %w", err)
 	}
 
+	currentLanguage, err := h.db.GetDefaultLanguage(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve current privacy mode: %w", err)
+	}
+
 	return map[string]interface{}{
-		"CurrentMode":    currentMode,
-		"PrivacyModes":   privacyModes,
-		csrf.TemplateTag: csrf.TemplateField(req),
+		"CurrentMode":     currentMode,
+		"CurrentLanguage": h.loc.ChooseTranslation(currentLanguage),
+		"PrivacyModes":    privacyModes,
+		csrf.TemplateTag:  csrf.TemplateField(req),
 	}, nil
 }
 
-func (h settingsHandler) setPrivacy(w http.ResponseWriter, req *http.Request) {
-	if req.Method != "POST" {
-		// TODO: proper error type
-		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request"))
+func (h settingsHandler) setLanguage(w http.ResponseWriter, req *http.Request) {
+	if !h.verifyPostRequirements(w, req) {
 		return
 	}
 
-	if err := req.ParseForm(); err != nil {
-		// TODO: proper error type
-		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request: %w", err))
-		return
-	}
-
-	// get the member behind the POST
-	currentMember := members.FromContext(req.Context())
+	// handles error cases & make sures the member is an admin
+	currentMember := h.getMember(w, req)
 	if currentMember == nil {
-		err := weberrors.ErrForbidden{Details: fmt.Errorf("not a registered member")}
-		h.r.Error(w, req, http.StatusInternalServerError, err)
 		return
 	}
 
-	// make sure the member is an admin
-	if currentMember.Role != roomdb.RoleAdmin {
-		err := weberrors.ErrForbidden{Details: fmt.Errorf("yr not an admin! naughty naughty")}
-		h.r.Error(w, req, http.StatusInternalServerError, err)
+	langTag := req.Form.Get("lang")
+
+	err := h.db.SetDefaultLanguage(req.Context(), langTag)
+	if err != nil {
+		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("something went wrong when setting the default language: %w", err))
+	}
+
+	// we successfully set the default language! time to redirect to the updated settings overview
+	h.redirect(router.AdminSettings, w, req)
+}
+
+func (h settingsHandler) setPrivacy(w http.ResponseWriter, req *http.Request) {
+	if !h.verifyPostRequirements(w, req) {
+		return
+	}
+	// handles error cases & make sures the member is an admin
+	currentMember := h.getMember(w, req)
+	if currentMember == nil {
 		return
 	}
 
@@ -78,6 +90,44 @@ func (h settingsHandler) setPrivacy(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// we successfully set the privacy mode! time to redirect to the updated settings overview
-	overview := h.urlTo(router.AdminSettings).String()
-	http.Redirect(w, req, overview, http.StatusFound)
+	h.redirect(router.AdminSettings, w, req)
+}
+
+/* common-use functions */
+
+func (h settingsHandler) getMember(w http.ResponseWriter, req *http.Request) *roomdb.Member {
+	// get the member behind the POST
+	currentMember := members.FromContext(req.Context())
+	if currentMember == nil {
+		err := weberrors.ErrForbidden{Details: fmt.Errorf("not a registered member")}
+		h.r.Error(w, req, http.StatusInternalServerError, err)
+		return nil
+	}
+
+	// make sure the member is an admin
+	if currentMember.Role != roomdb.RoleAdmin {
+		err := weberrors.ErrForbidden{Details: fmt.Errorf("yr not an admin! naughty naughty")}
+		h.r.Error(w, req, http.StatusInternalServerError, err)
+		return nil
+	}
+	return currentMember
+}
+
+func (h settingsHandler) verifyPostRequirements(w http.ResponseWriter, req *http.Request) bool {
+	if req.Method != "POST" {
+		// TODO: proper error type
+		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request"))
+		return false
+	}
+	if err := req.ParseForm(); err != nil {
+		// TODO: proper error type
+		h.r.Error(w, req, http.StatusBadRequest, fmt.Errorf("bad request: %w", err))
+		return false
+	}
+	return true
+}
+
+func (h settingsHandler) redirect(route string, w http.ResponseWriter, req *http.Request) {
+	overview := h.urlTo(route).String()
+	http.Redirect(w, req, overview, http.StatusSeeOther)
 }

--- a/web/handlers/admin/settings.go
+++ b/web/handlers/admin/settings.go
@@ -19,10 +19,10 @@ import (
 )
 
 type settingsHandler struct {
-	r   *render.Renderer
+	r     *render.Renderer
 	urlTo web.URLMaker
-	db  roomdb.RoomConfig
-	loc *i18n.Helper
+	db    roomdb.RoomConfig
+	loc   *i18n.Helper
 }
 
 func (h settingsHandler) overview(w http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/web/handlers/admin/setup_test.go
+++ b/web/handlers/admin/setup_test.go
@@ -64,6 +64,7 @@ func newSession(t *testing.T) *testSession {
 	ts.ConfigDB = new(mockdb.FakeRoomConfig)
 	// default mode for all tests
 	ts.ConfigDB.GetPrivacyModeReturns(roomdb.ModeCommunity, nil)
+	ts.ConfigDB.GetDefaultLanguageReturns("en", nil)
 	ts.DeniedKeysDB = new(mockdb.FakeDeniedKeysService)
 	ts.MembersDB = new(mockdb.FakeMembersService)
 	ts.PinnedDB = new(mockdb.FakePinnedNoticesService)
@@ -107,7 +108,7 @@ func newSession(t *testing.T) *testSession {
 	i18ntesting.WriteReplacement(t)
 
 	testRepo := repo.New(testPath)
-	locHelper, err := i18n.New(testRepo)
+	locHelper, err := i18n.New(testRepo, ts.ConfigDB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +132,7 @@ func newSession(t *testing.T) *testSession {
 	testFuncs["is_logged_in"] = func() *roomdb.Member { return &ts.User }
 	testFuncs["urlToNotice"] = func(name string) string { return "" }
 	testFuncs["language_count"] = func() int { return 1 }
-	testFuncs["list_languages"] = func() string { return "" }
+	testFuncs["list_languages"] = func(*url.URL, string) string { return "" }
 	testFuncs["relative_time"] = func(when time.Time) string { return humanize.Time(when) }
 
 	renderOpts := []render.Option{
@@ -153,6 +154,7 @@ func newSession(t *testing.T) *testSession {
 		r,
 		ts.RoomState,
 		flashHelper,
+		locHelper,
 		Databases{
 			Aliases:       ts.AliasesDB,
 			Config:        ts.ConfigDB,

--- a/web/handlers/admin/setup_test.go
+++ b/web/handlers/admin/setup_test.go
@@ -130,6 +130,8 @@ func newSession(t *testing.T) *testSession {
 	testFuncs["current_page_is"] = func(routeName string) bool { return true }
 	testFuncs["is_logged_in"] = func() *roomdb.Member { return &ts.User }
 	testFuncs["urlToNotice"] = func(name string) string { return "" }
+	testFuncs["language_count"] = func() int { return 1 }
+	testFuncs["list_languages"] = func() string { return "" }
 	testFuncs["relative_time"] = func(when time.Time) string { return humanize.Time(when) }
 
 	renderOpts := []render.Option{

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -204,6 +204,7 @@ func New(
 	}
 
 	CSRF := csrf.Protect(csrfKey,
+		csrf.Path("/"),
 		csrf.ErrorHandler(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			err := csrf.FailureReason(req)
 			// TODO: localize error?

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -7,7 +7,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
-  "strings"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log/level"
@@ -283,7 +283,7 @@ func New(
 
 		session, err := cookieStore.Get(req, i18n.LanguageCookieName)
 		if err != nil {
-			eh.Handle(w, req, http.StatusInternalServerError,err)
+			eh.Handle(w, req, http.StatusInternalServerError, err)
 			return
 		}
 

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -275,7 +275,6 @@ func New(
 	m.Get(router.CompleteSetLanguage).HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		lang := req.FormValue("lang")
 		previousRoute := req.FormValue("page")
-		fmt.Println(lang, previousRoute)
 
 		session, err := cookieStore.Get(req, i18n.LanguageCookieName)
 		if err != nil {
@@ -283,16 +282,13 @@ func New(
 			return
 		}
 
-		prevCookie := session.Values["lang"]
-		fmt.Println("previous cookie", prevCookie)
-
 		session.Values["lang"] = lang
 		err = session.Save(req, w)
 		if err != nil {
 			fmt.Printf("we failed to save the language session cookie %w\n", err)
 		}
 
-		http.Redirect(w, req, previousRoute, http.StatusTemporaryRedirect)
+		http.Redirect(w, req, previousRoute, http.StatusSeeOther)
 	})
 
 	// landing page

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -152,8 +152,8 @@ func New(
 			return func(postRoute *url.URL, classList string) template.HTML {
 				languages := locHelper.ListLanguages()
 				languageOptions := make([]string, len(languages))
-				for tag, translation := range languages {
-					languageOptions = append(languageOptions, createFormElement(postRoute.String(), tag, translation, classList))
+				for _, entry := range languages {
+					languageOptions = append(languageOptions, createFormElement(postRoute.String(), entry.Tag, entry.Translation, classList))
 				}
 				return (template.HTML)(strings.Join(languageOptions, "\n"))
 			}

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -283,14 +283,16 @@ func New(
 
 		session, err := cookieStore.Get(req, i18n.LanguageCookieName)
 		if err != nil {
-			fmt.Errorf("cookie error? %w\n", err)
+			eh.Handle(w, req, http.StatusInternalServerError,err)
 			return
 		}
 
 		session.Values["lang"] = lang
 		err = session.Save(req, w)
 		if err != nil {
-			fmt.Errorf("we failed to save the language session cookie %w\n", err)
+			err = fmt.Errorf("we failed to save the language session cookie %w\n", err)
+			eh.Handle(w, req, http.StatusInternalServerError, err)
+			return
 		}
 
 		http.Redirect(w, req, previousRoute, http.StatusSeeOther)

--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -123,10 +123,15 @@ func New(
 			}
 		}),
 
-		render.InjectTemplateFunc("listLanguages", func(r *http.Request) interface{} {
+		render.InjectTemplateFunc("language_count", func(r *http.Request) interface{} {
+			return func() int {
+				return len(locHelper.ListLanguages())
+			}
+		}),
+
+		render.InjectTemplateFunc("list_languages", func(r *http.Request) interface{} {
 			urlTo := web.NewURLTo(m)
 			route := urlTo(router.CompleteSetLanguage).String()
-			// seem to get an error when changing languages on pages that already embed a csrf token
 			csrfElement := csrf.TemplateField(r)
 
 			createFormElement := func(tag, translation string) string {

--- a/web/handlers/invites_test.go
+++ b/web/handlers/invites_test.go
@@ -116,7 +116,7 @@ func TestInviteConsumeInviteHTTP(t *testing.T) {
 	doc, resp := ts.Client.GetHTML(validAcceptURL)
 	a.Equal(http.StatusOK, resp.Code)
 
-	form := doc.Find("form#consume")
+	form := doc.Find("form#inviteConsume")
 	r.Equal(1, form.Length())
 
 	consumeInviteURLString, has := form.Attr("action")
@@ -131,7 +131,7 @@ func TestInviteConsumeInviteHTTP(t *testing.T) {
 	})
 
 	// get the corresponding token from the page
-	csrfTokenElem := doc.Find(`form[action="/invite/consume"] input[name="gorilla.csrf.Token"]`)
+	csrfTokenElem := form.Find(`input[name="gorilla.csrf.Token"]`)
 	a.Equal(1, csrfTokenElem.Length())
 	csrfName, has := csrfTokenElem.Attr("name")
 	a.True(has, "should have a name attribute")

--- a/web/handlers/invites_test.go
+++ b/web/handlers/invites_test.go
@@ -131,7 +131,7 @@ func TestInviteConsumeInviteHTTP(t *testing.T) {
 	})
 
 	// get the corresponding token from the page
-	csrfTokenElem := doc.Find("input[name='gorilla.csrf.Token']")
+	csrfTokenElem := doc.Find(`form[action="/invite/consume"] input[name="gorilla.csrf.Token"]`)
 	a.Equal(1, csrfTokenElem.Length())
 	csrfName, has := csrfTokenElem.Attr("name")
 	a.True(has, "should have a name attribute")

--- a/web/handlers/language_template.go
+++ b/web/handlers/language_template.go
@@ -1,0 +1,27 @@
+package handlers
+
+import "html/template"
+
+type changeLanguageTemplateData struct {
+	PostRoute    string
+	CSRFElement  template.HTML
+	LangTag      string
+	RedirectPage string
+	Translation  string
+	ClassList    string
+}
+
+var changeLanguageTemplate = template.Must(template.New("changeLanguageForm").Parse(`
+<form
+  action="{{ .PostRoute }}"
+  method="POST"
+>
+  {{ .CSRFElement }}
+  <input type="hidden" name="lang" value="{{ .LangTag }}">
+  <input type="hidden" name="page" value="{{ .RedirectPage }}">
+  <input
+    type="submit"
+    value="{{ .Translation }}"
+    class="{{ .ClassList }}"
+  />
+</form>`))

--- a/web/handlers/notices_test.go
+++ b/web/handlers/notices_test.go
@@ -92,7 +92,7 @@ func TestNoticesEditButtonVisible(t *testing.T) {
 	csrfCookie := resp.Result().Cookies()
 	a.True(len(csrfCookie) > 0, "should have one cookie for CSRF protection validation")
 
-	csrfTokenElem := doc.Find(`form[action="/fallback/finalize"] input[type="hidden"]`)
+	csrfTokenElem := doc.Find(`form#password-fallback input[type="hidden"]`)
 	a.Equal(1, csrfTokenElem.Length())
 
 	csrfName, has := csrfTokenElem.Attr("name")

--- a/web/handlers/notices_test.go
+++ b/web/handlers/notices_test.go
@@ -92,7 +92,7 @@ func TestNoticesEditButtonVisible(t *testing.T) {
 	csrfCookie := resp.Result().Cookies()
 	a.True(len(csrfCookie) > 0, "should have one cookie for CSRF protection validation")
 
-	csrfTokenElem := doc.Find("input[type=hidden]")
+	csrfTokenElem := doc.Find(`form[action="/fallback/finalize"] input[type="hidden"]`)
 	a.Equal(1, csrfTokenElem.Length())
 
 	csrfName, has := csrfTokenElem.Attr("name")

--- a/web/handlers/set_language_test.go
+++ b/web/handlers/set_language_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	// "github.com/ssb-ngi-pointer/go-ssb-room/roomdb"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/i18n"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
+)
+
+func TestLanguageDefaultNoCookie(t *testing.T) {
+	ts := setup(t)
+	a := assert.New(t)
+	route := ts.URLTo(router.CompleteIndex)
+	postEndpoint := ts.URLTo(router.CompleteSetLanguage)
+	formAction := postEndpoint.Path
+
+	html, res := ts.Client.GetHTML(route)
+	a.Equal(http.StatusOK, res.Code, "wrong HTTP status code")
+
+	languageForms := html.Find(fmt.Sprintf(`form[action="%s"]`, formAction))
+	// two languages: english, deutsch => two <form> elements
+	a.Equal(2, languageForms.Length())
+
+	// verify there is no language cookie to set yet
+	cookieHeader := res.Header()["Set-Cookie"]
+	for _, cookie := range cookieHeader {
+		cookieName := strings.Split(cookie, "=")[0]
+		a.NotEqual(cookieName, i18n.LanguageCookieName)
+	}
+}
+
+func TestLanguageChooseGerman(t *testing.T) {
+	ts := setup(t)
+	a := assert.New(t)
+	route := ts.URLTo(router.CompleteIndex)
+	postEndpoint := ts.URLTo(router.CompleteSetLanguage)
+	formAction := postEndpoint.Path
+
+	html, res := ts.Client.GetHTML(route)
+	a.Equal(http.StatusOK, res.Code, "wrong HTTP status code")
+
+	csrfTokenElem := html.Find(fmt.Sprintf(`form[action="%s"] input[type="hidden"]`, formAction))
+	a.Equal(6, csrfTokenElem.Length())
+
+	csrfName, has := csrfTokenElem.First().Attr("name")
+	a.True(has, "should have a name attribute")
+
+	csrfValue, has := csrfTokenElem.First().Attr("value")
+	a.True(has, "should have value attribute")
+
+	// construct the post request fields, simulating picking a language
+	setLanguageFields := url.Values{
+		"lang":   []string{"de"},
+		"page":   []string{"/"},
+		csrfName: []string{csrfValue},
+	}
+
+	// set the referer header (important! otherwise our nicely crafted request yields a 500 :'()
+	var refererHeader = make(http.Header)
+	refererHeader.Set("Referer", "https://localhost")
+	ts.Client.SetHeaders(refererHeader)
+
+	// send the post request
+	postRes := ts.Client.PostForm(postEndpoint, setLanguageFields)
+	a.Equal(http.StatusSeeOther, postRes.Code, "wrong HTTP status code for sign in")
+
+	// verify there is one language cookie to set
+	cookieHeader := postRes.Header()["Set-Cookie"]
+	var languageCookies int
+	for _, cookie := range cookieHeader {
+		cookieName := strings.Split(cookie, "=")[0]
+		if cookieName == i18n.LanguageCookieName {
+			languageCookies += 1
+		}
+	}
+	a.Equal(1, languageCookies, "should have one language cookie set after posting")
+}

--- a/web/handlers/set_language_test.go
+++ b/web/handlers/set_language_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	// "github.com/ssb-ngi-pointer/go-ssb-room/roomdb"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/i18n"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
 )

--- a/web/handlers/set_language_test.go
+++ b/web/handlers/set_language_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,13 +16,11 @@ func TestLanguageDefaultNoCookie(t *testing.T) {
 	ts := setup(t)
 	a := assert.New(t)
 	route := ts.URLTo(router.CompleteIndex)
-	postEndpoint := ts.URLTo(router.CompleteSetLanguage)
-	formAction := postEndpoint.Path
 
 	html, res := ts.Client.GetHTML(route)
 	a.Equal(http.StatusOK, res.Code, "wrong HTTP status code")
 
-	languageForms := html.Find(fmt.Sprintf(`form[action="%s"]`, formAction))
+	languageForms := html.Find("#visitor-set-language form")
 	// two languages: english, deutsch => two <form> elements
 	a.Equal(2, languageForms.Length())
 
@@ -40,13 +37,12 @@ func TestLanguageChooseGerman(t *testing.T) {
 	a := assert.New(t)
 	route := ts.URLTo(router.CompleteIndex)
 	postEndpoint := ts.URLTo(router.CompleteSetLanguage)
-	formAction := postEndpoint.Path
 
 	html, res := ts.Client.GetHTML(route)
 	a.Equal(http.StatusOK, res.Code, "wrong HTTP status code")
 
-	csrfTokenElem := html.Find(fmt.Sprintf(`form[action="%s"] input[type="hidden"]`, formAction))
-	a.Equal(6, csrfTokenElem.Length())
+	csrfTokenElem := html.Find(`#visitor-set-language input[name="gorilla.csrf.Token"]`)
+	a.Equal(2, csrfTokenElem.Length())
 
 	csrfName, has := csrfTokenElem.First().Attr("name")
 	a.True(has, "should have a name attribute")

--- a/web/i18n/defaults/active.de.toml
+++ b/web/i18n/defaults/active.de.toml
@@ -1,0 +1,206 @@
+LanguageName = "Deutsch"
+
+# generic terms
+GenericConfirm = "Ja"
+GenericGoBack = "Zurück"
+GenericSave = "Speichern"
+GenericCreate = "Erstellen"
+GenericSubmit = "Einreichen"
+GenericPreview = "Vorschau"
+GenericLanguage = "Sprache"
+GenericOpenLink = "Verbindung öffnen"
+
+PageNotFound = "Die angeforderte Seite wurde nicht gefunden."
+
+PubKeyRefPlaceholder = "@                                            .ed25519"
+
+# roles
+RoleMember = "Mitglied"
+RoleModerator = "Moderator"
+RoleAdmin = "Administrator"
+
+# navigation labels (should be single words or as short as possible)
+NavAdminLanding = "Zuhause"
+NavAdminDashboard = "Armaturenbrett"
+NavAdminInvites = "Einladungen"
+NavAdminNotices = "Hinweise"
+
+# Error messages
+ErrorAuthBadLogin = "Die angegebenen Authentifizierungsdaten (Benutzername oder Passwort) sind falsch."
+ErrorNotFound = "Die Datenbank konnte den betreffenden Artikel nicht finden."
+ErrorAlreadyAdded = "Der öffentliche Schlüssel <strong> {{.Key}} </ strong> ist bereits in der Liste enthalten."
+ErrorPageNotFound = "Die angeforderte Seite <strong> ({{.Path}}) </ strong> ist nicht vorhanden."
+ErrorNotAuthorized = "Sie sind nicht autorisiert auf diese Seite zuzugreifen."
+ErrorForbidden = "Die Anforderung konnte wegen fehlender Berechtigungen ({{.Details}}) nicht ausgeführt werden."
+ErrorBadRequest = "Bei Ihrer Anfrage ist ein Problem aufgetreten: {{.Where}} ({{.Details}}"
+
+# authentication
+################
+
+AuthTitle = "Mitgliederauthentifizierung"
+AuthWelcome = "Wenn Sie Mitglied dieses Raums sind, können Sie auf das interne Dashboard zugreifen. Klicken Sie unten auf Ihre bevorzugte Anmeldemethode:"
+
+AuthSignIn = "Einloggen"
+AuthSignOut = "Ausloggen"
+
+# auth with ssb
+AuthWithSSBTitle = "Mit SSB anmelden"
+AuthWithSSBInstruct = "Einfache und sichere Methode, wenn Ihre SSB-App dies unterstützt."
+AuthWithSSBWelcome = "Um sich mit Ihrer auf diesem Gerät gespeicherten SSB-Identität anzumelden, drücken Sie die Taste unten, um eine kompatible SSB-App zu öffnen, falls diese installiert ist."
+AuthWithSSBInstructQR = "Wenn sich Ihre SSB-App auf einem anderen Gerät befindet, können Sie den folgenden QR-Code scannen, um sich mit der SSB-Identität dieses Geräts anzumelden."
+AuthWithSSBError = "Anmeldung fehlgeschlagen. Stellen Sie sicher, dass Sie eine SSB-App verwenden, die diese Anmeldemethode unterstützt, und klicken Sie innerhalb einer Minute nach dem Öffnen dieser Seite auf die Schaltfläche oben."
+
+# auth with password
+AuthFallbackTitle = "Passwort anmelden"
+AuthFallbackWelcome = "Eine Anmeldung mit Benutzername und Passwort ist nur möglich, wenn der Administrator Ihnen eines gegeben hat, da wir die Benutzerregistrierung nicht unterstützen."
+AuthFallbackInstruct = "Diese Methode ist ein akzeptabler Fallback, wenn Sie einen Benutzernamen und ein Passwort haben."
+
+# general dashboard stuff
+#########################
+
+AdminDashboardTitle = "Armaturenbrett"
+AdminDashboardRoomID = "Der Ausweis dieses Zimmers lautet"
+
+# privacy modes
+###############
+
+ModeOpen = "Öffnen"
+ModeCommunity = "Gemeinschaft"
+ModeRestricted = "Eingeschränkt"
+
+SetPrivacyModeTitle = "Datenschutzmodus einstellen"
+PrivacyModesTitle = "Datenschutzmodi"
+RoomsSpecification = "Zimmer 2 Spezifikation"
+ExplanationPrivacyModes = "Der Datenschutzmodus dieses Raums bestimmt, wer Einladungen erstellen und wer eine Verbindung zum Raum herstellen kann. Weitere Informationen finden Sie unter"
+ExplanationOpen = "Öffnen Sie Einladungscodes, jeder kann eine Verbindung herstellen"
+ExplanationCommunity = "Mitglieder können Einladungen erstellen, jeder kann eine Verbindung herstellen"
+ExplanationRestricted = "Nur Administratoren / Mods können Einladungen erstellen, nur Mitglieder dürfen eine Verbindung herstellen."
+
+Settings = "Einstellungen"
+
+DefaultLanguageTitle = "Voreinstellung"
+ExplanationDefaultLanguage = "Die Standard-Sprachoption steuert die Sprache der Raum-Weboberfläche, die für Erstbesucher angezeigt wird. Die verfügbaren Sprachoptionen werden durch die installierten Übersetzungsdateien definiert."
+SetDefaultLanguageTitle = "Voreinstellung ändern"
+
+# banned dashboard
+##################
+
+AdminDeniedKeysTitle = "Verboten"
+AdminDeniedKeysWelcome = "Auf dieser Seite können SSB-IDs gesperrt werden, damit sie nicht mehr auf den Raum zugreifen können."
+AdminDeniedKeysAdd = "Hinzufügen"
+AdminDeniedKeysAdded = "Schlüssel wurde zur Liste hinzugefügt."
+AdminDeniedKeysRemove = "Entfernen"
+AdminDeniedKeysComment = "Kommentar"
+AdminDeniedKeysCommentDescription = "Die Person, die dieses Verbot hinzugefügt hat, hat den folgenden Kommentar hinzugefügt"
+AdminDeniedKeysRemoveConfirmWelcome = "Sind Sie sicher, dass Sie dieses Verbot aufheben möchten? Sie werden wieder Zugang zum Raum haben."
+AdminDeniedKeysRemoveConfirmTitle = "Mitgliederentfernung bestätigen"
+
+# members dashboard
+###################
+
+AdminMembersTitle = "Mitglieder"
+AdminMembersWelcome = "Hier sehen Sie alle Mitglieder des Raums und Möglichkeiten, neue hinzuzufügen (anhand ihrer SSB-ID) oder vorhandene zu entfernen."
+AdminMembersAdd = "Hinzufügen"
+
+AdminMembersRemoveConfirmTitle = "Mitgliederentfernung bestätigen"
+AdminMembersRemoveConfirmWelcome = "Sind Sie sicher, dass Sie dieses Mitglied entfernen möchten? Sie verlieren ihren Alias, wenn sie einen haben."
+
+AdminMemberDetailsTitle = "Mitgliederdetails"
+AdminMemberDetailsSSBID = "SSB-Kennung"
+AdminMemberDetailsRole = "Berechtigungsstufe"
+AdminMemberDetailsAliases = "Aliase"
+AdminMemberDetailsAliasRevoke = "Widerrufen"
+AdminMemberDetailsAliasRevoked = "Alias ​​wurde widerrufen"
+AdminMemberDetailsExclusion = "Ausschluss aus diesem Raum"
+AdminMemberDetailsRemove = "Mitglied entfernen"
+
+AdminMemberAdded = "Mitglied erfolgreich hinzugefügt."
+AdminMemberUpdated = "Mitglied aktualisiert."
+AdminMemberRemoved = "Mitglied entfernt."
+
+AdminAliasesRevoke = "Widerrufen"
+AdminAliasesRevokeConfirmTitle = "Alias ​​widerrufen"
+AdminAliasesRevokeConfirmWelcome = "Sind Sie sicher, dass Sie diesen Alias ​​widerrufen möchten?"
+
+# invite dashboard
+##################
+
+AdminInvitesTitle = "Einladungen"
+AdminInvitesWelcome = "Erstellen Sie Einladungs-Token für Personen, die noch keine Mitglieder dieses Raums sind. Auf dieser Seite sehen Sie auch zuvor erstellte Einladungen, die von neuen Mitgliedern noch nicht beansprucht werden."
+AdminInvitesCreate = "Neue Einladung erstellen"
+AdminInvitesCreatedAtColumn = "Hergestellt in"
+AdminInvitesCreatorColumn = "Erstellt von"
+AdminInvitesActionColumn = "Aktion"
+AdminInviteRevoke = "Widerrufen"
+
+AdminInviteRevokeConfirmTitle = "Widerruf der Einladung bestätigen"
+AdminInviteRevokeConfirmWelcome = "Sind Sie sicher, dass Sie diese Einladung entfernen möchten? Wenn Sie sie bereits gesendet haben, können sie sie nicht verwenden."
+
+# TODO: add placeholder support to the template helpers (https://github.com/ssb-ngi-pointer/go-ssb-room/issues/60)
+AdminInviteCreatedBy = "Erstellt von:"
+AdminInviteSuggestedAliasIs = "Der vorgeschlagene Alias ​​lautet:"
+AdminInviteSuggestedAliasIsShort = "Alias:"
+
+AdminInviteCreatedTitle = "Einladung erfolgreich erstellt!"
+AdminInviteCreatedInstruct = "Kopieren Sie nun den folgenden Link und fügen Sie ihn in einen Freund ein, den Sie in diesen Raum einladen möchten."
+
+# public invites
+################
+
+InviteFacade = "Raum betreten"
+InviteFacadeTitle = "Raum betreten"
+InviteFacadeWelcome = "Sie haben die Erlaubnis, Mitglied dieses Raums zu werden, weil jemand diese Einladung mit Ihnen geteilt hat."
+InviteFacadeInstruct = "Um die Einladung zu erhalten, klicken Sie auf die Schaltfläche unten, um eine kompatible SSB-App zu öffnen, falls diese installiert ist."
+InviteFacadeJoin = "Tritt diesem Raum bei"
+InviteFacadeWaiting = "SSB App öffnen"
+InviteFacadeInstructQR = "Wenn sich Ihre SSB-App auf einem anderen Gerät befindet, können Sie den folgenden QR-Code scannen, um Ihre Einladung auf diesem Gerät zu erhalten:"
+
+InviteFacadeFallbackWelcome = "Sind Sie neu bei SSB? Es scheint, dass Sie keine SSB-App haben, die diesen Link verstehen kann. Sie können eine dieser Apps installieren:"
+InviteFacadeFallbackManyverse = "Installiere Manyverse"
+InviteFacadeFallbackInsertID = "SSB-ID einfügen"
+
+InviteInsertWelcome = "Sie können Ihre Einladung anfordern, indem Sie unten Ihre SSB-ID eingeben. Danach können Sie in Ihrer SSB-App eine Verbindung zum Raum herstellen."
+
+InviteConsumedTitle = "Einladung angenommen!"
+InviteConsumedWelcome = "Sie sind jetzt Mitglied dieses Raums. Wenn Sie eine Multiserver-Adresse benötigen, um eine Verbindung zum Raum herzustellen, können Sie die folgende kopieren und einfügen:"
+
+# notices (mini-CMS)
+####################
+
+NoticeEditTitle = "Hinweis bearbeiten"
+NoticeList = "Hinweise"
+NoticeListWelcome = "Hier können Sie den Inhalt der Zielseite und anderer wichtiger Dokumente wie Verhaltenskodex und Datenschutzbestimmungen verwalten."
+NoticeAddTranslation = "Hinzufügen"
+NoticeUpdated = "Hinweis aktualisiert"
+
+NoticeCodeOfConduct = "Verhaltenskodex"
+NoticeNews = "Nachrichten"
+NoticeDescription = "Beschreibung"
+NoticePrivacyPolicy = "Datenschutz-Bestimmungen"
+
+# Plurals
+#########
+# These need to use this form and get {{.Count}}
+#   [Label]
+#   one = singular
+#   other = {{.Count}} things
+
+[MemberCount]
+description = "Anzahl der Mitglieder"
+one = "1 Mitglied"
+other =   "{{.Count}} Mitglieder"
+
+[ListCount]
+description = "generische Liste"
+one = "Es gibt einen Punkt auf der Liste"
+other =   "Die Liste enthält {{.Count}} Elemente"
+
+[AdminRoomCount]
+description = "Die Anzahl der Personen in einem Raum"
+one = "Es ist eine Person im Raum"
+other =  "Es sind {{.Count}} Personen im Raum"
+
+[AdminInvitesCount]
+description = "die Anzahl der Einladungen, die noch nicht beansprucht wurden"
+one = "1 Einladung noch nicht beansprucht"
+other = "{{.Count}} lädt noch nicht beanspruchte ein"

--- a/web/i18n/defaults/active.en.toml
+++ b/web/i18n/defaults/active.en.toml
@@ -1,5 +1,7 @@
 # default localiztion file for english
-MetaLanguage = "English"
+
+# the name of this language, in its language. Used for language picking
+LanguageName = "English"
 
 # generic terms
 GenericConfirm = "Yes"

--- a/web/i18n/defaults/active.en.toml
+++ b/web/i18n/defaults/active.en.toml
@@ -83,6 +83,10 @@ ExplanationOpen = "Open invite codes, anyone may connect"
 ExplanationCommunity = "Members can create invites, anyone may connect"
 ExplanationRestricted = "Only admins/mods can create invites, only members may connect"
 
+DefaultLanguageTitle = "Default Language"
+ExplanationDefaultLanguage = "The default language option controls the room web interface language displayed for first time visitors. The available languages options are defined by the installed translation files."
+SetDefaultLanguageTitle = "Set Default Language"
+
 Settings = "Settings"
 
 # banned dashboard

--- a/web/i18n/defaults/active.en.toml
+++ b/web/i18n/defaults/active.en.toml
@@ -1,4 +1,5 @@
 # default localiztion file for english
+MetaLanguage = "English"
 
 # generic terms
 GenericConfirm = "Yes"

--- a/web/i18n/helper.go
+++ b/web/i18n/helper.go
@@ -157,9 +157,9 @@ func listLanguages(bundle *i18n.Bundle) map[string]string {
 	return langmap
 }
 
-// ListLanguages returns a mapping between the room's translated languages.
-// The keys are language tags (as strings) and the values are the name of the language tag, as translated in the original language.
-// For example: en -> English, sv -> Svenska, de -> Deutsch
+// ListLanguages returns a map of the room's translated languages.
+// The map's keys are language tags (as strings) and the corresponding value is the translated language name.
+// Example: en -> English, sv -> Svenska, de -> Deutsch
 func (h Helper) ListLanguages() map[string]string {
 	return h.languages
 }

--- a/web/i18n/helper.go
+++ b/web/i18n/helper.go
@@ -185,7 +185,6 @@ func (h Helper) FromRequest(r *http.Request) *Localizer {
 
 	session, err := h.cookieStore.Get(r, LanguageCookieName)
 	if err != nil {
-		fmt.Printf("cookie error? %w\n", err)
 		return h.newLocalizer(lang, accept)
 	}
 

--- a/web/i18n/i18ntesting/i18n_helper_test.go
+++ b/web/i18n/i18ntesting/i18n_helper_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/i18n"
 )
 
-func TestListAllLanguages(t *testing.T) {
+func TestListLanguages(t *testing.T) {
 	configDB := new(mockdb.FakeRoomConfig)
 	configDB.GetDefaultLanguageReturns("en", nil)
 	r := repo.New(filepath.Join("testrun", t.Name()))
@@ -18,6 +18,6 @@ func TestListAllLanguages(t *testing.T) {
 	helper, err := i18n.New(r, configDB)
 	a.NoError(err)
 	t.Log(helper)
-	langmap := helper.ListLanguages()
-	a.Equal(langmap["en"], "English")
+	translation := helper.ChooseTranslation("en")
+	a.Equal(translation, "English")
 }

--- a/web/i18n/i18ntesting/i18n_helper_test.go
+++ b/web/i18n/i18ntesting/i18n_helper_test.go
@@ -1,0 +1,20 @@
+package i18ntesting
+
+import (
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+	"testing"
+
+	"github.com/ssb-ngi-pointer/go-ssb-room/internal/repo"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/i18n"
+)
+
+func TestListAllLanguages(t *testing.T) {
+	r := repo.New(filepath.Join("testrun", t.Name()))
+	a := assert.New(t)
+	helper, err := i18n.New(r)
+	a.NoError(err)
+	t.Log(helper)
+	langmap := helper.ListLanguages()
+	a.Equal(langmap["en"], "English")
+}

--- a/web/i18n/i18ntesting/i18n_helper_test.go
+++ b/web/i18n/i18ntesting/i18n_helper_test.go
@@ -6,13 +6,16 @@ import (
 	"testing"
 
 	"github.com/ssb-ngi-pointer/go-ssb-room/internal/repo"
+	"github.com/ssb-ngi-pointer/go-ssb-room/roomdb/mockdb"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/i18n"
 )
 
 func TestListAllLanguages(t *testing.T) {
+	configDB := new(mockdb.FakeRoomConfig)
+	configDB.GetDefaultLanguageReturns("en", nil)
 	r := repo.New(filepath.Join("testrun", t.Name()))
 	a := assert.New(t)
-	helper, err := i18n.New(r)
+	helper, err := i18n.New(r, configDB)
 	a.NoError(err)
 	t.Log(helper)
 	langmap := helper.ListLanguages()

--- a/web/i18n/i18ntesting/i18n_test.go
+++ b/web/i18n/i18ntesting/i18n_test.go
@@ -3,6 +3,7 @@ package i18ntesting
 import (
 	"bytes"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -66,7 +67,17 @@ func justTheKeys(t *testing.T) []byte {
 	return buf.Bytes()
 }
 
-func WriteReplacement(t *testing.T) {
+func TestListAllLanguages(t *testing.T) {
+	r := repo.New(filepath.Join("testrun", t.Name()))
+	a := assert.New(t)
+	helper, err := i18n.New(r)
+	a.NoError(err)
+	t.Log(helper)
+	langmap := helper.ListLanguages()
+	a.Equal(langmap["en"], "English")
+}
+
+func TestWriteReplacement(t *testing.T) {
 	r := repo.New(filepath.Join("testrun", t.Name()))
 
 	testOverride := filepath.Join(r.GetPath("i18n"), "active.en.toml")

--- a/web/i18n/i18ntesting/testing.go
+++ b/web/i18n/i18ntesting/testing.go
@@ -3,7 +3,6 @@ package i18ntesting
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -67,17 +66,7 @@ func justTheKeys(t *testing.T) []byte {
 	return buf.Bytes()
 }
 
-func TestListAllLanguages(t *testing.T) {
-	r := repo.New(filepath.Join("testrun", t.Name()))
-	a := assert.New(t)
-	helper, err := i18n.New(r)
-	a.NoError(err)
-	t.Log(helper)
-	langmap := helper.ListLanguages()
-	a.Equal(langmap["en"], "English")
-}
-
-func TestWriteReplacement(t *testing.T) {
+func WriteReplacement(t *testing.T) {
 	r := repo.New(filepath.Join("testrun", t.Name()))
 
 	testOverride := filepath.Join(r.GetPath("i18n"), "active.en.toml")

--- a/web/router/admin.go
+++ b/web/router/admin.go
@@ -9,8 +9,9 @@ const (
 	AdminDashboard = "admin:dashboard"
 	AdminMenu      = "admin:menu"
 
-	AdminSettings           = "admin:settings:overview"
-	AdminSettingsSetPrivacy = "admin:settings:set-privacy"
+	AdminSettings            = "admin:settings:overview"
+	AdminSettingsSetPrivacy  = "admin:settings:set-privacy"
+	AdminSettingsSetLanguage = "admin:settings:set-language"
 
 	AdminAliasesRevokeConfirm = "admin:aliases:revoke:confirm"
 	AdminAliasesRevoke        = "admin:aliases:revoke"
@@ -49,6 +50,7 @@ func Admin(m *mux.Router) *mux.Router {
 
 	m.Path("/settings").Methods("GET").Name(AdminSettings)
 	m.Path("/settings/set-privacy").Methods("POST").Name(AdminSettingsSetPrivacy)
+	m.Path("/settings/set-language").Methods("POST").Name(AdminSettingsSetLanguage)
 
 	m.Path("/menu").Methods("GET").Name(AdminMenu)
 

--- a/web/router/complete.go
+++ b/web/router/complete.go
@@ -14,6 +14,8 @@ const (
 	CompleteNoticeShow = "complete:notice:show"
 	CompleteNoticeList = "complete:notice:list"
 
+  CompleteSetLanguage = "complete:set-language"
+
 	CompleteAliasResolve = "complete:alias:resolve"
 
 	CompleteInviteFacade         = "complete:invite:accept"
@@ -41,6 +43,8 @@ func CompleteApp() *mux.Router {
 
 	m.Path("/notice/show").Methods("GET").Name(CompleteNoticeShow)
 	m.Path("/notice/list").Methods("GET").Name(CompleteNoticeList)
+
+	m.Path("/set-language").Methods("POST").Name(CompleteSetLanguage)
 
 	return m
 }

--- a/web/router/complete.go
+++ b/web/router/complete.go
@@ -14,7 +14,7 @@ const (
 	CompleteNoticeShow = "complete:notice:show"
 	CompleteNoticeList = "complete:notice:list"
 
-  CompleteSetLanguage = "complete:set-language"
+	CompleteSetLanguage = "complete:set-language"
 
 	CompleteAliasResolve = "complete:alias:resolve"
 

--- a/web/templates/admin/settings.tmpl
+++ b/web/templates/admin/settings.tmpl
@@ -4,55 +4,71 @@
     class="text-3xl tracking-tight font-black text-black mt-2 mb-0"
   >{{ i18n "Settings" }}</h1>
 
-  <div class="flex flex-col-reverse sm:flex-row justify-start items-stretch ">
-    <div class="max-w-lg">
-      <h2 class="text-xl tracking-tight font-bold text-black mt-2 mb-2">{{ i18n "PrivacyModesTitle" }}</h2>
-      <p class="mb-4">
-        {{ i18n "ExplanationPrivacyModes" }} 
-        <a class="text-pink-600 underline" href="https://ssb-ngi-pointer.github.io/rooms2/#privacy-modes">{{ i18n "RoomsSpecification" }}</a>.
-      </p>
-    <h3 class="text-gray-400 text-sm font-bold mb-2">{{ i18n "SetPrivacyModeTitle" }}</h3>
-    <details class="mb-8 self-start w-96" id="change-privacy">
-      <summary class="px-3 py-1 w-96 rounded shadow bg-white ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
-      {{ i18n .CurrentMode.String }}
-      </summary>
+  <div class="max-w-2xl">
+    <h2 class="text-xl tracking-tight font-bold text-black mt-2 mb-2">{{ i18n "PrivacyModesTitle" }}</h2>
+    <p class="mb-4">
+      {{ i18n "ExplanationPrivacyModes" }} 
+      <a class="text-pink-600 underline" href="https://ssb-ngi-pointer.github.io/rooms2/#privacy-modes">{{ i18n "RoomsSpecification" }}</a>.
+    </p>
+  <h3 class="text-gray-400 text-sm font-bold mb-2">{{ i18n "SetPrivacyModeTitle" }}</h3>
+  <details class="mb-8 self-start max-w-sm" id="change-privacy">
+    <summary class="px-3 py-1 max-w-sm rounded shadow bg-white ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
+    {{ i18n .CurrentMode.String }}
+    </summary>
 
-      <div class="absolute w-96 z-10 bg-white mt-2 shadow-xl ring-1 ring-gray-200 rounded divide-y flex flex-col items-stretch overflow-hidden">
-        {{ range .PrivacyModes }}
-            {{ if ne . $.CurrentMode }}
-            <form
-              action="{{ urlTo "admin:settings:set-privacy" }}"
-              method="POST"
-              >
-              {{ $.csrfField }}
-              <input type="hidden" name="privacy_mode" value="{{.}}">
-              <input
-                type="submit"
-                value="{{ i18n .String }}"
-                class="pl-10 pr-3 py-2 w-full text-left bg-white text-gray-700 hover:text-gray-900 hover:bg-gray-50 cursor-pointer"
-                />
-            </form>
-            {{ else }}
-            <div class="pr-3 py-2 text-gray-600 flex flex-row items-center cursor-default">
-              <div class="w-10 flex flex-row items-center justify-center">
-                <svg class="w-4 h-4" viewBox="0 0 24 24">
-                  <path fill="currentColor" d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
-                </svg>
-              </div>
-              <span>{{ i18n .String }}</span>
+    <div class="absolute max-w-sm z-10 bg-white mt-2 shadow-xl ring-1 ring-gray-200 rounded divide-y flex flex-col items-stretch overflow-hidden">
+      {{ range .PrivacyModes }}
+          {{ if ne . $.CurrentMode }}
+          <form
+            action="{{ urlTo "admin:settings:set-privacy" }}"
+            method="POST"
+            >
+            {{ $.csrfField }}
+            <input type="hidden" name="privacy_mode" value="{{.}}">
+            <input
+              type="submit"
+              value="{{ i18n .String }}"
+              class="pl-10 pr-3 py-2 w-full text-left bg-white text-gray-700 hover:text-gray-900 hover:bg-gray-50 cursor-pointer"
+              />
+          </form>
+          {{ else }}
+          <div class="pr-3 py-2 text-gray-600 flex flex-row items-center cursor-default">
+            <div class="w-10 flex flex-row items-center justify-center">
+              <svg class="w-4 h-4" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+              </svg>
             </div>
-            {{end}}
-        {{end}}
-      </div>
-    </details>
-      <div class="grid max-w-lg grid-cols-3 gap-y-2 mb-8">
-        <div class="text-xl text-gray-500 font-bold">{{ i18n "ModeOpen" }}</div>
-        <div class="text-md col-span-2 italic">{{ i18n "ExplanationOpen" }}</div>
-        <div class="text-xl text-gray-500 font-bold">{{ i18n "ModeCommunity" }}</div>
-        <div class="text-md col-span-2 italic">{{ i18n "ExplanationCommunity" }}</div>
-        <div class="text-xl text-gray-500 font-bold">{{ i18n "ModeRestricted" }}</div>
-        <div class="text-md col-span-2 italic">{{ i18n "ExplanationRestricted" }}</div>
-      </div>
+            <span>{{ i18n .String }}</span>
+          </div>
+          {{end}}
+      {{end}}
     </div>
+  </details>
+    <div class="grid max-w-lg grid-cols-3 gap-y-2 mb-8">
+      <div class="text-xl text-gray-500 font-bold">{{ i18n "ModeOpen" }}</div>
+      <div class="text-md col-span-2 italic">{{ i18n "ExplanationOpen" }}</div>
+      <div class="text-xl text-gray-500 font-bold">{{ i18n "ModeCommunity" }}</div>
+      <div class="text-md col-span-2 italic">{{ i18n "ExplanationCommunity" }}</div>
+      <div class="text-xl text-gray-500 font-bold">{{ i18n "ModeRestricted" }}</div>
+      <div class="text-md col-span-2 italic">{{ i18n "ExplanationRestricted" }}</div>
+    </div>
+  </div>
+  <div class="max-w-2xl">
+    <h2 class="text-xl tracking-tight font-bold text-black mt-2 mb-2">{{ i18n "DefaultLanguageTitle" }}</h2>
+    <p class="mb-4">
+      {{ i18n "ExplanationDefaultLanguage" }} 
+    </p>
+  <h3 class="text-gray-400 text-sm font-bold mb-2">{{ i18n "SetDefaultLanguageTitle" }}</h3>
+  <details class="mb-8 self-start max-w-sm">
+    <summary class="px-3 py-1 max-w-sm rounded shadow bg-white ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
+    {{ $.CurrentLanguage }}
+    </summary>
+    <div class="mt-2 bg-gray bg-white px-3 rounded ring-1 ring-gray-300">
+       {{ $adminSetLanguageUrl := urlTo "admin:settings:set-language" }}
+       {{ list_languages $adminSetLanguageUrl "pl-10 pr-3 py-2 w-full text-left bg-white text-gray-700 hover:text-gray-900 hover:bg-gray-50 cursor-pointer" }}
+    </div>
+  </details>
+  </div>
+
   </div>
 {{end}}

--- a/web/templates/admin/settings.tmpl
+++ b/web/templates/admin/settings.tmpl
@@ -60,7 +60,7 @@
     </p>
   <h3 class="text-gray-400 text-sm font-bold mb-2">{{ i18n "SetDefaultLanguageTitle" }}</h3>
   <details class="mb-8 self-start max-w-sm">
-    <summary class="px-3 py-1 max-w-sm rounded shadow bg-white ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
+    <summary id="language-summary" class="px-3 py-1 max-w-sm rounded shadow bg-white ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
     {{ $.CurrentLanguage }}
     </summary>
     <div class="mt-2 bg-gray bg-white px-3 rounded ring-1 ring-gray-300">

--- a/web/templates/base.tmpl
+++ b/web/templates/base.tmpl
@@ -95,16 +95,8 @@
           class="mb-2 mx-auto px-3 py-1 text-gray-500 w-32 rounded shadow bg-gray-50 ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
           Language
           </summary>
-          <div
-           class="grid grid-cols-2 justify-items-center gap-x-1">
-            <a href="" class="text-gray-500 bold hover:underline">English</a>
-            <a href="" class="text-gray-500 hover:underline">Hmong</a>
-            <a href="" class="text-gray-500 hover:underline">Унáҥам Тунý</a>
-            <a href="" class="text-gray-500 hover:underline">Suomi</a>
-            <a href="" class="text-gray-500 hover:underline">Русский</a>
-            <a href="" class="text-gray-500 hover:underline">xapaitíiso</a>
-            <a href="" class="text-gray-500 hover:underline">Português</a>
-            <a href="" class="text-gray-500 hover:underline">Svenska</a>
+          <div class="grid grid-cols-2 justify-items-center gap-x-1">
+           {{ listLanguages }}
           </div>
         </details>
       </div>

--- a/web/templates/base.tmpl
+++ b/web/templates/base.tmpl
@@ -12,7 +12,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon/favicon-16x16.png">
   <link rel="manifest" href="/assets/favicon/site.webmanifest">
 </head>
-<body class="bg-gray-100">
+<body class="bg-gray-100 overflow-y-scroll">
   <div class="sm:mx-auto sm:container">
     <div class="flex flex-row justify-end space-x-4 my-4">
       {{$user := is_logged_in}}
@@ -70,23 +70,44 @@
     {{block "footer" .}}
     {{$cocUrl := urlToNotice "NoticeCodeOfConduct"}}
     {{$ppUrl := urlToNotice "NoticePrivacyPolicy"}}
-    <footer class="mb-4 flex flex-row items-center justify-center divide-x divide-gray-300">
-      <a
-        href="{{urlTo "complete:index"}}"
-        class="px-4 text-gray-500 hover:underline"
-        >{{i18n "NavAdminLanding"}}</a>
-      {{if $cocUrl}}
-      <a
-        href="{{$cocUrl}}"
-        class="px-4 text-gray-500 hover:underline"
-        >{{i18n "NoticeCodeOfConduct"}}</a>
-      {{end}}
-      {{if $ppUrl}}
-      <a
-        href="{{$ppUrl}}"
-        class="px-4 text-gray-500 hover:underline"
-        >{{i18n "NoticePrivacyPolicy"}}</a>
-      {{end}}
+    <footer class="grid auto-rows-min mb-12">
+    <div class="mb-4 flex flex-row items-center justify-center divide-x divide-gray-300">
+        <a
+          href="{{urlTo "complete:index"}}"
+          class="px-4 text-gray-500 hover:underline"
+          >{{i18n "NavAdminLanding"}}</a>
+        {{if $cocUrl}}
+        <a
+          href="{{$cocUrl}}"
+          class="px-4 text-gray-500 hover:underline"
+          >{{i18n "NoticeCodeOfConduct"}}</a>
+        {{end}}
+        {{if $ppUrl}}
+        <a
+          href="{{$ppUrl}}"
+          class="px-4 text-gray-500 hover:underline"
+          >{{i18n "NoticePrivacyPolicy"}}</a>
+        {{end}}
+      </div>
+      <div class="flex justify-center">
+        <details class="w-72">
+          <summary
+          class="mb-2 mx-auto px-3 py-1 text-gray-500 w-32 rounded shadow bg-gray-50 ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
+          Language
+          </summary>
+          <div
+           class="grid grid-cols-2 justify-items-center gap-x-1">
+            <a href="" class="text-gray-500 bold hover:underline">English</a>
+            <a href="" class="text-gray-500 hover:underline">Hmong</a>
+            <a href="" class="text-gray-500 hover:underline">Унáҥам Тунý</a>
+            <a href="" class="text-gray-500 hover:underline">Suomi</a>
+            <a href="" class="text-gray-500 hover:underline">Русский</a>
+            <a href="" class="text-gray-500 hover:underline">xapaitíiso</a>
+            <a href="" class="text-gray-500 hover:underline">Português</a>
+            <a href="" class="text-gray-500 hover:underline">Svenska</a>
+          </div>
+        </details>
+      </div>
     </footer>
     {{end}}
   </div>

--- a/web/templates/base.tmpl
+++ b/web/templates/base.tmpl
@@ -98,7 +98,7 @@
               class="mb-2 mx-auto px-3 py-1 text-gray-500 w-32 rounded shadow bg-gray-50 ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
               Language
               </summary>
-              <div class="grid grid-cols-2 justify-items-center gap-x-1">
+              <div id="visitor-set-language" class="grid grid-cols-2 justify-items-center gap-x-1">
                {{ list_languages $setLanguageUrl "text-gray-500 hover:underline cursor-pointer" }}
               </div>
             </details>

--- a/web/templates/base.tmpl
+++ b/web/templates/base.tmpl
@@ -70,6 +70,7 @@
     {{block "footer" .}}
     {{$cocUrl := urlToNotice "NoticeCodeOfConduct"}}
     {{$ppUrl := urlToNotice "NoticePrivacyPolicy"}}
+    {{$setLanguageUrl := urlTo "complete:set-language"}}
     <footer class="grid auto-rows-min mb-12">
     <div class="mb-4 flex flex-row items-center justify-center divide-x divide-gray-300">
         <a
@@ -98,7 +99,7 @@
               Language
               </summary>
               <div class="grid grid-cols-2 justify-items-center gap-x-1">
-               {{ list_languages }}
+               {{ list_languages $setLanguageUrl "text-gray-500 hover:underline cursor-pointer" }}
               </div>
             </details>
           {{ end }}

--- a/web/templates/base.tmpl
+++ b/web/templates/base.tmpl
@@ -90,15 +90,18 @@
         {{end}}
       </div>
       <div class="flex justify-center">
-        <details class="w-72">
-          <summary
-          class="mb-2 mx-auto px-3 py-1 text-gray-500 w-32 rounded shadow bg-gray-50 ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
-          Language
-          </summary>
-          <div class="grid grid-cols-2 justify-items-center gap-x-1">
-           {{ listLanguages }}
-          </div>
-        </details>
+          {{ $languages := language_count }}
+          {{ if gt $languages 1 }}
+            <details class="w-72">
+              <summary
+              class="mb-2 mx-auto px-3 py-1 text-gray-500 w-32 rounded shadow bg-gray-50 ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
+              Language
+              </summary>
+              <div class="grid grid-cols-2 justify-items-center gap-x-1">
+               {{ list_languages }}
+              </div>
+            </details>
+          {{ end }}
       </div>
     </footer>
     {{end}}

--- a/web/templates/invite/insert-id.tmpl
+++ b/web/templates/invite/insert-id.tmpl
@@ -4,7 +4,7 @@
   <span id="welcome" class="text-center mt-8">{{i18n "InviteInsertWelcome"}}</span>
 
   <form
-    id="consume"
+    id="inviteConsume"
     action="{{urlTo "complete:invite:consume"}}"
     method="POST"
     class="flex flex-col items-center self-stretch"


### PR DESCRIPTION
![2021-04-13-163635_1309x1033_scrot](https://user-images.githubusercontent.com/3862362/114572723-09d69b00-9c78-11eb-9575-85bada132d99.png)
Closes #45 

tasks
* [x] for each translated language, use the language name as defined in its original language
  * [x] hack: add key `LanguageName` defining the language name of a given translation?
* [x] get the list of all currently translated languages (for iterating over in template)
* [x] add a route somewhere for accepting the `/change-language` POST request
* [x] do the cookie stuff per details in #45
* [x] tweak `web/i18n/helper.go` to query for any language cookies & use the corresponding language translation if the cookie is set
* [x] only render language picker when we have `>= 2` language translations to pick from
* [x] add default language setting to admin settings page
* [x] fix `/set-language` only working on non-admin pages (bizarre csrf error), fixed in bbd77b4
* [x] sort language options
* [x] add bool to settings table; column name `use_subdomain_for_aliases` with a default of `1`
* [x] test
  * [x] admin: set default language correctly sets language option in database
  * [x] user: posting `/set-language` sets a language cookie 
