### PR TITLE
fix invite QR code

### DIFF
--- a/web/handlers/invites.go
+++ b/web/handlers/invites.go
@@ -81,7 +81,14 @@ func (h inviteHandler) presentFacade(rw http.ResponseWriter, req *http.Request) 
 	fallbackURL := urlTo(router.CompleteInviteFacadeFallback, "token", token)
 
 	// generate a QR code with the token inside so that you can open it easily in a supporting mobile app
-	qrCode, err := qrcode.New(string(joinRoomURI), qrcode.Medium)
+	thisURL := req.URL
+	thisURL.Host = h.networkInfo.Domain
+	thisURL.Scheme = "https"
+	if h.networkInfo.Development {
+		thisURL.Scheme = "http"
+		thisURL.Host += fmt.Sprintf(":%d", h.networkInfo.PortHTTPS)
+	}
+	qrCode, err := qrcode.New(thisURL.String(), qrcode.Medium)
 	if err != nil {
 		return nil, err
 	}

--- a/web/i18n/defaults/active.en.toml
+++ b/web/i18n/defaults/active.en.toml
@@ -153,6 +153,7 @@ InviteFacadeWelcome = "You have permission to become a member of this room becau
 InviteFacadeInstruct = "To claim the invite, press the button below which will open a compatible SSB app, if it's installed."
 InviteFacadeJoin = "Join this room"
 InviteFacadeWaiting = "Opening SSB app"
+InviteFacadeInstructQR = "If your SSB app is on another device, you can scan the following QR code to claim your invite on that device:"
 
 InviteFacadeFallbackWelcome = "Are you new to SSB? It seems you don't have an SSB app capable of understanding that link. You can install one of these apps:"
 InviteFacadeFallbackManyverse = "Install Manyverse"

--- a/web/templates/invite/facade.tmpl
+++ b/web/templates/invite/facade.tmpl
@@ -16,7 +16,7 @@
 
   <hr class="mt-8 w-64 h-px bg-gray-200"></hr>
 
-  <span class="text-center mt-8">{{i18n "AuthWithSSBInstructQR"}}</span>
+  <span class="text-center mt-8">{{i18n "InviteFacadeInstructQR"}}</span>
 
   <img
     id="start-auth-qrcode"


### PR DESCRIPTION
The claim-invite QR code should not be the SSB URI (because most mobile scanners don't support it), it should be a web URL.