### PR TITLE
disable ui if user is unelevated

### DIFF
--- a/web/handlers/admin/set_language_test.go
+++ b/web/handlers/admin/set_language_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ssb-ngi-pointer/go-ssb-room/roomdb"
 	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,6 +34,10 @@ func TestLanguageSetDefaultLanguage(t *testing.T) {
 	a := assert.New(t)
 
 	ts.ConfigDB.GetDefaultLanguageReturns("de", nil)
+	ts.User = roomdb.Member{
+		ID:   1234,
+		Role: roomdb.RoleAdmin,
+	}
 
 	u := ts.URLTo(router.AdminSettings)
 	html, resp := ts.Client.GetHTML(u)

--- a/web/handlers/admin/settings_test.go
+++ b/web/handlers/admin/settings_test.go
@@ -1,0 +1,100 @@
+package admin
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ssb-ngi-pointer/go-ssb-room/roomdb"
+	"github.com/ssb-ngi-pointer/go-ssb-room/web/router"
+)
+
+func TestSettingsOverview(t *testing.T) {
+	ts := newSession(t)
+	a := assert.New(t)
+
+	/* First: make sure everything renders correctly for admins */
+	ts.User = roomdb.Member{
+		ID:   1234,
+		Role: roomdb.RoleAdmin,
+	}
+
+	ts.ConfigDB.GetPrivacyModeReturns(roomdb.ModeCommunity, nil)
+	ts.ConfigDB.GetDefaultLanguageReturns("en", nil)
+
+	settingsURL := ts.URLTo(router.AdminSettings)
+
+	html, resp := ts.Client.GetHTML(settingsURL)
+	a.Equal(http.StatusOK, resp.Code, "wrong HTTP status code")
+
+	// the privacy mode form & its summary/details container should exist
+	privacyFormContainer := html.Find("#change-privacy")
+	a.Equal(1, privacyFormContainer.Length())
+	a.Equal(1, privacyFormContainer.Find("summary").Length())
+	// chosen privacy mode is ModeCommunity (english translation will only be the name of the label, due to testing suite is set up atm)
+	a.Equal("ModeCommunity", strings.TrimSpace(privacyFormContainer.Find("summary").Text()))
+	// details-dropdown should have two forms, one for each of the other two privacy modes
+	// that can be selected (ModeOpen, ModeRestricted)
+	a.Equal(2, privacyFormContainer.Find("form").Length())
+	// and one span, showing the selected mode
+	a.Equal(1, privacyFormContainer.Find("#selected-mode").Length())
+	inputs := privacyFormContainer.Find("input")
+	// verify none of the privacy mode container's inputs are disabled
+	inputs.Each(func(i int, el *goquery.Selection) {
+		_, exists := el.Attr("disabled")
+		a.False(exists)
+	})
+
+	// verify that the change language form exists & is enabled
+	languageFormContainer := html.Find("#change-language-container")
+	a.Equal(1, languageFormContainer.Length())
+	a.Equal(1, languageFormContainer.Find("summary").Length())
+	// (english translation will only be the name of the label, due to testing suite is set up atm)
+	a.Equal("LanguageName", strings.TrimSpace(languageFormContainer.Find("summary").Text()))
+
+	testDisabledBehaviour := func() {
+		settingsURL := ts.URLTo(router.AdminSettings)
+		html, resp := ts.Client.GetHTML(settingsURL)
+		a.Equal(http.StatusOK, resp.Code, "wrong HTTP status code")
+
+		// we do not have the summary/details hack if the forms are hidden
+		privacyFormContainer := html.Find("#change-privacy")
+		a.Equal(0, privacyFormContainer.Length())
+		// the should still be the parent container, however
+		privacyContainer := html.Find("#privacy-mode-container")
+		a.Equal(1, privacyContainer.Length())
+		// there should only be one input in the privacy mode container now
+		inputs := privacyContainer.Find("input")
+		a.Equal(1, inputs.Length())
+		// the input should be disabled
+		_, disabled := inputs.Attr("disabled")
+		a.True(disabled)
+
+		// next, verify that the change language setting is disabled
+		languageContainer := html.Find("#change-language-container")
+		a.Equal(1, languageContainer.Length())
+		// there should only be one input in the language mode container now
+		inputs = languageContainer.Find("input")
+		a.Equal(1, inputs.Length())
+		// the input should be disabled
+		_, disabled = inputs.Attr("disabled")
+		a.True(disabled)
+	}
+
+	/* Now: verify that moderators cannot make room settings changes */
+	ts.User = roomdb.Member{
+		ID:   7331,
+		Role: roomdb.RoleModerator,
+	}
+	testDisabledBehaviour()
+
+	/* Finally: verify that members cannot make room settings changes */
+	ts.User = roomdb.Member{
+		ID:   9001,
+		Role: roomdb.RoleMember,
+	}
+	testDisabledBehaviour()
+}

--- a/web/handlers/admin/setup_test.go
+++ b/web/handlers/admin/setup_test.go
@@ -133,6 +133,10 @@ func newSession(t *testing.T) *testSession {
 	testFuncs["urlToNotice"] = func(name string) string { return "" }
 	testFuncs["language_count"] = func() int { return 1 }
 	testFuncs["list_languages"] = func(*url.URL, string) string { return "" }
+	testFuncs["member_is_elevated"] = func() bool { return true }
+	testFuncs["member_is_admin"] = func() bool { return true }
+	testFuncs["member_can_invite"] = func() bool { return true }
+	testFuncs["list_languages"] = func(*url.URL, string) string { return "" }
 	testFuncs["relative_time"] = func(when time.Time) string { return humanize.Time(when) }
 
 	renderOpts := []render.Option{

--- a/web/handlers/admin/setup_test.go
+++ b/web/handlers/admin/setup_test.go
@@ -133,9 +133,14 @@ func newSession(t *testing.T) *testSession {
 	testFuncs["urlToNotice"] = func(name string) string { return "" }
 	testFuncs["language_count"] = func() int { return 1 }
 	testFuncs["list_languages"] = func(*url.URL, string) string { return "" }
-	testFuncs["member_is_elevated"] = func() bool { return true }
-	testFuncs["member_is_admin"] = func() bool { return true }
-	testFuncs["member_can_invite"] = func() bool { return true }
+	testFuncs["member_is_elevated"] = func() bool { return ts.User.Role == roomdb.RoleAdmin || ts.User.Role == roomdb.RoleModerator }
+	testFuncs["member_is_admin"] = func() bool { return ts.User.Role == roomdb.RoleAdmin }
+	testFuncs["member_can_invite"] = func() bool {
+		pm, _ := ts.ConfigDB.GetPrivacyMode(ctx)
+		memberElevated := ts.User.Role == roomdb.RoleAdmin || ts.User.Role == roomdb.RoleModerator
+		memberCanInvite := ts.User.Role == roomdb.RoleMember && (pm == roomdb.ModeCommunity || pm == roomdb.ModeOpen)
+		return memberElevated || memberCanInvite
+	}
 	testFuncs["list_languages"] = func(*url.URL, string) string { return "" }
 	testFuncs["relative_time"] = func(when time.Time) string { return humanize.Time(when) }
 

--- a/web/handlers/notices_test.go
+++ b/web/handlers/notices_test.go
@@ -109,7 +109,7 @@ func TestNoticesEditButtonVisible(t *testing.T) {
 	}
 
 	// have the database return okay for any user
-	testUser := roomdb.Member{ID: 23}
+	testUser := roomdb.Member{ID: 23, Role: roomdb.RoleAdmin}
 	ts.AuthFallbackDB.CheckReturns(testUser.ID, nil)
 	ts.MembersDB.GetByIDReturns(testUser, nil)
 

--- a/web/i18n/defaults/active.de.toml
+++ b/web/i18n/defaults/active.de.toml
@@ -117,6 +117,7 @@ AdminMemberDetailsRemove = "Mitglied entfernen"
 AdminMemberAdded = "Mitglied erfolgreich hinzugefügt."
 AdminMemberUpdated = "Mitglied aktualisiert."
 AdminMemberRemoved = "Mitglied entfernt."
+AdminAddNewMemberTitle = "Add a new member"
 
 AdminAliasesRevoke = "Widerrufen"
 AdminAliasesRevokeConfirmTitle = "Alias ​​widerrufen"

--- a/web/i18n/defaults/active.en.toml
+++ b/web/i18n/defaults/active.en.toml
@@ -124,6 +124,7 @@ AdminMemberDetailsRemove = "Remove member"
 AdminMemberAdded = "Member added successfully."
 AdminMemberUpdated = "Member updated."
 AdminMemberRemoved = "Member removed."
+AdminAddNewMemberTitle = "Add a new member"
 
 AdminAliasesRevoke = "Revoke"
 AdminAliasesRevokeConfirmTitle = "Revoke Alias"

--- a/web/members/helper.go
+++ b/web/members/helper.go
@@ -100,7 +100,7 @@ func ContextInjecter(mdb roomdb.MembersService, withPassword *auth.Handler, with
 //
 //  {{ member_is_admin }} is a shortcut for {{ member_has_role "RoleAdmin" }}
 //
-//  {{ member_is_admin }} is a shortcut for {{ or member_has_role "RoleAdmin" member_has_role "RoleModerator"}}
+//  {{ member_is_elevated }} is a shortcut for {{ or member_has_role "RoleAdmin" member_has_role "RoleModerator"}}
 func TemplateHelpers() []render.Option {
 
 	return []render.Option{

--- a/web/templates/admin/denied-keys.tmpl
+++ b/web/templates/admin/denied-keys.tmpl
@@ -20,7 +20,7 @@
       method="POST"
     >
       {{ .csrfField }}
-      <div class="flex flex-row items-center h-12">
+      <div id="denied-keys-input-container" class="flex flex-row items-center h-12">
         <input
           {{ if member_is_elevated }} {{ else }} disabled {{ end }}
           type="text"

--- a/web/templates/admin/denied-keys.tmpl
+++ b/web/templates/admin/denied-keys.tmpl
@@ -22,21 +22,32 @@
       {{ .csrfField }}
       <div class="flex flex-row items-center h-12">
         <input
+          {{ if member_is_elevated }} {{ else }} disabled {{ end }}
           type="text"
           name="pub_key"
           placeholder="{{i18n "PubKeyRefPlaceholder"}}"
-          class="font-mono truncate w-1/2 mr-2 tracking-wider h-12 text-gray-900 focus:outline-none focus:ring-1 focus:ring-green-500 focus:border-transparent placeholder-gray-300"
+          class="p-1 rounded font-mono truncate w-1/2 mr-2 tracking-wider h-12 shadow text-gray-900 focus:outline-none focus:ring-1
+          focus:ring-green-500 focus:border-transparent placeholder-gray-300 
+          {{ if member_is_elevated }} {{ else }} shadow ring-1 ring-gray-300 opacity-50 bg-gray-200 cursor-not-allowed {{ end }}
+          "
         >
         <input
+          {{ if member_is_elevated }} {{ else }} disabled {{ end }}
           type="text"
           name="comment"
           placeholder="{{i18n "AdminDeniedKeysComment"}}"
-          class="font-mono truncate w-1/2  tracking-wider h-12 text-gray-900 focus:outline-none focus:ring-1 focus:ring-green-500 focus:border-transparent placeholder-gray-300"
+          class="p-1 rounded font-mono truncate w-1/2 mr-2 tracking-wider h-12 shadow text-gray-900 focus:outline-none focus:ring-1
+          focus:ring-green-500 focus:border-transparent placeholder-gray-300 
+          {{ if member_is_elevated }} {{ else }} shadow ring-1 ring-gray-300 opacity-50 bg-gray-200 cursor-not-allowed {{ end }}
+          "
         >
         <input
+          {{ if member_is_elevated }} {{ else }} disabled {{ end }}
           type="submit"
           value="{{i18n "AdminDeniedKeysAdd"}}"
-          class="pl-4 w-20 py-2 text-center text-green-500 hover:text-green-600 font-bold bg-transparent cursor-pointer"
+          class="pl-4 w-20 py-2 text-center font-bold bg-transparent disabled:opacity-50
+          {{ if member_is_elevated }} text-green-500 hover:text-green-600 cursor-pointer {{ else }} text-gray-200 cursor-not-allowed {{ end }}
+          "
         >
       </div>
     </form>

--- a/web/templates/admin/invite-list.tmpl
+++ b/web/templates/admin/invite-list.tmpl
@@ -28,8 +28,15 @@
             >
             {{ .csrfField }}
             <button
+              {{ if not member_can_invite }} disabled {{ end }}
               type="submit"
-              class="shadow rounded px-3 py-1.5 text-green-600 ring-1 ring-green-400 bg-white hover:bg-green-500 hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-green-400"
+              class="shadow rounded px-3 py-1.5 ring-1 focus:outline-none focus:ring-2 
+              {{ if member_can_invite }} 
+                text-green-600 ring-green-400 bg-white hover:bg-green-500 hover:text-gray-100 focus:ring-green-400 
+              {{ else }} 
+                text-gray-500 ring-gray-200 bg-gray-300 cursor-not-allowed 
+              {{ end }}
+              "
               >{{i18n "AdminInvitesCreate"}}</button>
           </form>
         </td>
@@ -44,6 +51,8 @@
 
     <tbody id="the-table-rows" class="divide-y">
       {{range .Entries}}
+        {{ $user := is_logged_in }}
+        {{$hasCreatedInvite := eq $user.PubKey.Ref .CreatedBy.PubKey.Ref }}
         {{$creator := .CreatedBy.PubKey.Ref}}
         {{$creatorIsAlias := false}}
         {{range $index, $alias := .CreatedBy.Aliases}}
@@ -67,10 +76,12 @@
           {{end}}
         </td>
         <td class="w-3/12 pl-2 pr-3 text-right">
+        {{ if or member_is_elevated $hasCreatedInvite }}
           <a
             href="{{urlTo "admin:invites:revoke:confirm" "id" .ID}}"
             class="pl-2 w-20 py-2 text-center text-gray-400 hover:text-red-600 font-bold cursor-pointer"
           >{{i18n "AdminInviteRevoke"}}</a>
+        {{ end }}
         </td>
       </tr>
       <tr class="h-12 table-row sm:hidden">
@@ -84,10 +95,12 @@
                 >{{$creator}}</span>, {{human_time .CreatedAt}}
             {{end}}
           </span>
-          <a
-            href="{{urlTo "admin:invites:revoke:confirm" "id" .ID}}"
-            class="pl-4 w-20 py-2 text-center text-gray-400 hover:text-red-600 font-bold cursor-pointer"
-            >{{i18n "AdminInviteRevoke"}}</a>
+          {{ if or member_is_elevated $hasCreatedInvite }}
+            <a
+              href="{{urlTo "admin:invites:revoke:confirm" "id" .ID}}"
+              class="pl-4 w-20 py-2 text-center text-gray-400 hover:text-red-600 font-bold cursor-pointer"
+              >{{i18n "AdminInviteRevoke"}}</a>
+          {{ end }}
         </td>
       </tr>
       {{end}}

--- a/web/templates/admin/member-list.tmpl
+++ b/web/templates/admin/member-list.tmpl
@@ -15,7 +15,7 @@
   >
     {{ .csrfField }}
     <label class="block mt-6 mb-1 text-sm text-gray-500">{{ i18n "AdminAddNewMemberTitle" }}</label>
-    <div class="flex flex-row items-center justify-start mb-6">
+    <div id="add-member-input-container" class="flex flex-row items-center justify-start mb-6">
       <input
         {{ if member_is_elevated }} {{ else }} disabled {{ end }}
         type="text"

--- a/web/templates/admin/member-list.tmpl
+++ b/web/templates/admin/member-list.tmpl
@@ -14,16 +14,23 @@
     method="POST"
   >
     {{ .csrfField }}
-    <label class="block mt-6 mb-1 text-sm text-gray-500">Add a new member</label>
+    <label class="block mt-6 mb-1 text-sm text-gray-500">{{ i18n "AdminAddNewMemberTitle" }}</label>
     <div class="flex flex-row items-center justify-start mb-6">
       <input
+        {{ if member_is_elevated }} {{ else }} disabled {{ end }}
         type="text"
         name="pub_key"
         placeholder="{{i18n "PubKeyRefPlaceholder"}}"
-        class="w-8/12 self-stretch shadow rounded border border-transparent h-10 p-1 pl-4 font-mono truncate text-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent">
+        class="w-8/12 self-stretch shadow rounded border border-transparent h-10 p-1 pl-4 font-mono truncate 
+        text-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent
+        {{ if member_is_elevated }} {{ else }} shadow ring-1 ring-gray-300 opacity-50 bg-gray-200 cursor-not-allowed {{ end }}
+        ">
       <button
+        {{ if member_is_elevated }} {{ else }} disabled {{ end }}
         type="submit"
-        class="ml-4 h-10 shadow rounded px-6 text-purple-600 ring-1 ring-purple-400 bg-white hover:bg-purple-600 hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-400"
+        class="ml-4 h-10 shadow rounded px-6 text-purple-600 ring-1 bg-white focus:outline-none focus:ring-2 focus:ring-purple-400
+        {{ if member_is_elevated }} ring-purple-400 hover:bg-purple-600 hover:text-gray-100 {{ else }} opacity-50 ring-purple-300 bg-purple-200 cursor-not-allowed {{ end }}
+        "
         >{{i18n "AdminMembersAdd"}}</button>
     </div>
   </form>

--- a/web/templates/admin/member.tmpl
+++ b/web/templates/admin/member.tmpl
@@ -8,45 +8,55 @@
   <p id="ssb-id" class="mb-8 font-mono font-bold tracking-wider truncate text-gray-900">{{.Member.PubKey.Ref}}</p>
 
   <label class="mt-2 mb-1 font-bold text-gray-400 text-sm">{{i18n "AdminMemberDetailsRole"}}</label>
-  <details class="mb-8 self-start w-40" id="change-role">
-    <summary class="px-3 py-1 rounded shadow bg-white ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
+  {{ $user := is_logged_in }}
+  {{ $aliasBelongsToUser := eq $user.PubKey.Ref .Member.PubKey.Ref }}
+  {{ if member_is_elevated }}
+    <details class="mb-8 self-start w-40" id="change-role">
+      <summary class="px-3 py-1 rounded shadow bg-white ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
+        {{range $.AllRoles}}
+          {{if eq . $.Member.Role}}
+            {{i18n .String}}
+          {{end}}
+        {{end}}
+      </summary>
+
+      <div class="absolute z-10 bg-white w-40 mt-2 shadow-xl ring-1 ring-gray-200 rounded divide-y flex flex-col items-stretch overflow-hidden">
+        {{range $.AllRoles}}
+            {{if ne . $.Member.Role}}
+              <form
+                action="{{urlTo "admin:members:change-role" "id" $.Member.ID}}"
+                method="POST"
+                >
+                {{$.csrfField}}
+                <input type="hidden" name="role" value="{{.}}">
+                <input
+                  type="submit"
+                  value="{{i18n .String}}"
+                  class="pl-10 pr-3 py-2 w-full text-left bg-white text-gray-700 hover:text-gray-900 hover:bg-gray-50 cursor-pointer"
+                  />
+              </form>
+            {{else}}
+              <div
+                class="pr-3 py-2 text-gray-600 flex flex-row items-center cursor-default"
+                >
+                <div class="w-10 flex flex-row items-center justify-center">
+                  <svg class="w-4 h-4" viewBox="0 0 24 24">
+                    <path fill="currentColor" d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+                  </svg>
+                </div>
+                <span>{{i18n .String}}</span>
+              </div>
+            {{end}}
+        {{end}}
+      </div>
+    </details>
+    {{ else }}
       {{range $.AllRoles}}
         {{if eq . $.Member.Role}}
-          {{i18n .String}}
-        {{end}}
+            <p id="ssb-member-role" class="mb-8 font-bold tracking-wider truncate text-gray-900">{{i18n .String}}</p>
+          {{end}}
       {{end}}
-    </summary>
-
-    <div class="absolute z-10 bg-white w-40 mt-2 shadow-xl ring-1 ring-gray-200 rounded divide-y flex flex-col items-stretch overflow-hidden">
-      {{range $.AllRoles}}
-      {{if ne . $.Member.Role}}
-      <form
-        action="{{urlTo "admin:members:change-role" "id" $.Member.ID}}"
-        method="POST"
-        >
-        {{$.csrfField}}
-        <input type="hidden" name="role" value="{{.}}">
-        <input
-          type="submit"
-          value="{{i18n .String}}"
-          class="pl-10 pr-3 py-2 w-full text-left bg-white text-gray-700 hover:text-gray-900 hover:bg-gray-50 cursor-pointer"
-          />
-      </form>
-      {{else}}
-        <div
-          class="pr-3 py-2 text-gray-600 flex flex-row items-center cursor-default"
-          >
-          <div class="w-10 flex flex-row items-center justify-center">
-            <svg class="w-4 h-4" viewBox="0 0 24 24">
-              <path fill="currentColor" d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
-            </svg>
-          </div>
-          <span>{{i18n .String}}</span>
-        </div>
-      {{end}}
-      {{end}}
-    </div>
-  </details>
+    {{ end }}
 
   {{$aliasCount := len .Member.Aliases}} {{if gt $aliasCount 0}}
   <label class="mt-2 mb-1 font-bold text-gray-400 text-sm">{{i18n "AdminMemberDetailsAliases"}}</label>
@@ -59,19 +69,23 @@
         >{{.Name}}</a>
     </div>
 
-    <a
-      href="{{urlTo "admin:aliases:revoke:confirm" "id" .ID}}"
-      class="w-20 py-2 text-sm text-center text-gray-400 hover:text-red-600 font-bold cursor-pointer"
+    {{ if or member_is_elevated $aliasBelongsToUser }}
+      <a
+        href="{{urlTo "admin:aliases:revoke:confirm" "id" .ID}}"
+        class="w-20 py-2 text-sm text-center text-gray-400 hover:text-red-600 font-bold cursor-pointer"
       >({{i18n "AdminMemberDetailsAliasRevoke"}})</a>
+    {{end}}
   {{end}}
   </div>
   {{end}}
 
+  {{ if member_is_elevated }}
   <label class="mt-10 mb-1 font-bold text-gray-400 text-sm">{{i18n "AdminMemberDetailsExclusion"}}</label>
   <a
     id="remove-member"
     href="{{urlTo "admin:members:remove:confirm" "id" .Member.ID}}"
     class="mb-8 self-start shadow rounded px-3 py-1 text-red-600 ring-1 ring-red-400 bg-white hover:bg-red-600 hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-red-400 cursor-pointer"
     >{{i18n "AdminMemberDetailsRemove"}}</a>
+  {{ end }}
 
 {{end}}

--- a/web/templates/admin/settings.tmpl
+++ b/web/templates/admin/settings.tmpl
@@ -11,6 +11,7 @@
       <a class="text-pink-600 underline" href="https://ssb-ngi-pointer.github.io/rooms2/#privacy-modes">{{ i18n "RoomsSpecification" }}</a>.
     </p>
   <h3 class="text-gray-400 text-sm font-bold mb-2">{{ i18n "SetPrivacyModeTitle" }}</h3>
+  {{ if member_is_admin }}
   <details class="mb-8 self-start max-w-sm" id="change-privacy">
     <summary class="px-3 py-1 max-w-sm rounded shadow bg-white ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
     {{ i18n .CurrentMode.String }}
@@ -44,6 +45,11 @@
       {{end}}
     </div>
   </details>
+  {{ else }}
+  <input disabled type="text" value="{{ i18n $.CurrentMode.String }}" 
+   class="mb-8 self-start max-w-sm px-3 py-1 max-w-sm rounded shadow ring-1 ring-gray-300 bg-gray-200 opacity-50 cursor-not-allowed"
+  >
+  {{ end }}
     <div class="grid max-w-lg grid-cols-3 gap-y-2 mb-8">
       <div class="text-xl text-gray-500 font-bold">{{ i18n "ModeOpen" }}</div>
       <div class="text-md col-span-2 italic">{{ i18n "ExplanationOpen" }}</div>
@@ -59,6 +65,7 @@
       {{ i18n "ExplanationDefaultLanguage" }} 
     </p>
   <h3 class="text-gray-400 text-sm font-bold mb-2">{{ i18n "SetDefaultLanguageTitle" }}</h3>
+  {{ if member_is_admin }} 
   <details class="mb-8 self-start max-w-sm">
     <summary id="language-summary" class="px-3 py-1 max-w-sm rounded shadow bg-white ring-1 ring-gray-300 hover:bg-gray-100 cursor-pointer">
     {{ $.CurrentLanguage }}
@@ -68,6 +75,11 @@
        {{ list_languages $adminSetLanguageUrl "pl-10 pr-3 py-2 w-full text-left bg-white text-gray-700 hover:text-gray-900 hover:bg-gray-50 cursor-pointer" }}
     </div>
   </details>
+  {{ else }}
+  <input disabled type="text" value="{{ $.CurrentLanguage }}" 
+   class="mb-8 self-start max-w-sm px-3 py-1 max-w-sm rounded shadow ring-1 ring-gray-300 bg-gray-200 opacity-50 cursor-not-allowed"
+  >
+  {{ end }}
   </div>
 
   </div>

--- a/web/templates/admin/settings.tmpl
+++ b/web/templates/admin/settings.tmpl
@@ -4,7 +4,7 @@
     class="text-3xl tracking-tight font-black text-black mt-2 mb-0"
   >{{ i18n "Settings" }}</h1>
 
-  <div class="max-w-2xl">
+  <div class="max-w-2xl" id="privacy-mode-container">
     <h2 class="text-xl tracking-tight font-bold text-black mt-2 mb-2">{{ i18n "PrivacyModesTitle" }}</h2>
     <p class="mb-4">
       {{ i18n "ExplanationPrivacyModes" }} 
@@ -39,7 +39,7 @@
                 <path fill="currentColor" d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
               </svg>
             </div>
-            <span>{{ i18n .String }}</span>
+            <span id="selected-mode">{{ i18n .String }}</span>
           </div>
           {{end}}
       {{end}}
@@ -59,7 +59,7 @@
       <div class="text-md col-span-2 italic">{{ i18n "ExplanationRestricted" }}</div>
     </div>
   </div>
-  <div class="max-w-2xl">
+  <div class="max-w-2xl" id="change-language-container">
     <h2 class="text-xl tracking-tight font-bold text-black mt-2 mb-2">{{ i18n "DefaultLanguageTitle" }}</h2>
     <p class="mb-4">
       {{ i18n "ExplanationDefaultLanguage" }} 

--- a/web/templates/landing/index.tmpl
+++ b/web/templates/landing/index.tmpl
@@ -9,7 +9,7 @@
   </div>
 
   <div class="h-8"></div>
-  {{if is_logged_in}}
+  {{if and is_logged_in member_is_elevated }}
     <a
       id="edit-notice"
       href="{{urlTo "admin:notice:edit" "id" .ID}}"

--- a/web/templates/notice/list.tmpl
+++ b/web/templates/notice/list.tmpl
@@ -20,7 +20,7 @@
         >{{.Language}}</a>
       {{end}}
 
-      {{if is_logged_in}}
+      {{if and is_logged_in member_is_elevated }}
         <a
           href="{{urlTo "admin:notice:translation:draft" "name" .Name.String}}"
           class="inline-block rounded-full py-1 px-3 text-sm text-gray-500 font-bold border-2 border-dashed box-content border-gray-200 hover:border-transparent hover:bg-white hover:shadow"

--- a/web/templates/notice/show.tmpl
+++ b/web/templates/notice/show.tmpl
@@ -12,7 +12,7 @@
   </div>
 
   <div class="h-8"></div>
-  {{if is_logged_in}}
+    {{if and is_logged_in member_is_elevated }}
     <a
       id="edit-notice"
       href="{{urlTo "admin:notice:edit" "id" .ID}}"


### PR DESCRIPTION
This PR adds a couple new helper functions to determine the role of the member when viewing pages. It also introduces changes to the views if the member is not allowed to perform the various actions (manage permission levels, ban others, change room settings)

The following screenshots are from a user with the role member, in a room with the privacy mode community.
Closes #138 

**Tasks**
* [x] Disable alias ui as well?

**Tests**
```
if member:
YUP     cant change settings privacy mode
YUP     cant change settings default language
YUP     cant ban user
YUP     cant add new member
YUP     cant change user role in members show
YUP     restricted: cant create invite
YUP     community: can create invite
* cant click add new notice
* landing page does not have edit button

if mod:
YUP     cant change settings privacy mode
YUP     cant change settings default language
YUP     can ban user
YUP     can add new member
YUP     can change user role in members show
YUP     restricted: can create invite
YUP     community: can create invite
* can click add new notice
* landing page has edit button

if admin:
YUP     can change settings privacy mode
YUP     can change settings default language
YUP     can ban user
YUP     can add new member
YUP     can change user role in members show
YUP     restricted: can create invite
YUP     community: can create invite
* can click add new notice
* landing page has edit button
```

Note: The invite button on the invite page is not disabled, since the room mode is set to community. If it is set to restricted, the UI will change.
![2021-04-21-134831_1920x1200_scrot](https://user-images.githubusercontent.com/3862362/115549690-3a868800-a2a9-11eb-9d5b-81e24d19f248.png)
![2021-04-21-134836_1920x1200_scrot](https://user-images.githubusercontent.com/3862362/115549696-3b1f1e80-a2a9-11eb-8049-94cd01a1aeee.png)
![2021-04-21-134839_1920x1200_scrot](https://user-images.githubusercontent.com/3862362/115549697-3bb7b500-a2a9-11eb-95d0-68f3bb77766e.png)
![2021-04-21-134842_1920x1200_scrot](https://user-images.githubusercontent.com/3862362/115549698-3c504b80-a2a9-11eb-8f26-c83696ada48f.png)
![2021-04-21-134844_1920x1200_scrot](https://user-images.githubusercontent.com/3862362/115549700-3c504b80-a2a9-11eb-89a8-14430a6abdcc.png)
![2021-04-21-134845_1920x1200_scrot](https://user-images.githubusercontent.com/3862362/115549703-3ce8e200-a2a9-11eb-8cd0-562632f57142.png)
![2021-04-21-134847_1920x1200_scrot](https://user-images.githubusercontent.com/3862362/115549705-3d817880-a2a9-11eb-806a-19caa5401a08.png)
![2021-04-21-134848_1920x1200_scrot](https://user-images.githubusercontent.com/3862362/115549710-3d817880-a2a9-11eb-8749-94c5cc94ad10.png)

This PR closes #138. Also opened #176 to track RoleMember being able to create new notices.
