### PR TITLE
Fix nginx.cfg for alias resolve when using JSON

### DIFF
--- a/docs/nginx-example.conf
+++ b/docs/nginx-example.conf
@@ -40,7 +40,9 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_pass http://localhost:8899/alias/$alias;
+        # "rewrite" requests with subdomains to the non-wildcard url for alias resolving
+        # $is_args$args pass on ?encoding=json if present
+        proxy_pass http://localhost:8899/alias/$alias$is_args$args;
     }
 
     location / {


### PR DESCRIPTION
fixes #181

The location/proxy_pass rule stripped the rest of the request URL.
This makes sure the url arguments are passed on to backend correctly.

See also: https://dev.to/danielkun/nginx-everything-about-proxypass-2ona