### PR TITLE
rename address field in alias JSON resolver

### DIFF
--- a/web/handlers/aliases.go
+++ b/web/handlers/aliases.go
@@ -76,12 +76,12 @@ type aliasResponder interface {
 
 // aliasJSONResponse dictates the field names and format of the JSON response for the alias web endpoint
 type aliasJSONResponse struct {
-	Status    string `json:"status"`
-	Address   string `json:"address"`
-	RoomID    string `json:"roomId"`
-	UserID    string `json:"userId"`
-	Alias     string `json:"alias"`
-	Signature string `json:"signature"`
+	Status             string `json:"status"`
+	MultiserverAddress string `json:"multiserverAddress"`
+	RoomID             string `json:"roomId"`
+	UserID             string `json:"userId"`
+	Alias              string `json:"alias"`
+	Signature          string `json:"signature"`
 }
 
 // handles JSON responses
@@ -104,12 +104,12 @@ func (json *aliasJSONResponder) UpdateRoomInfo(netInfo network.ServerEndpointDet
 
 func (json aliasJSONResponder) SendConfirmation(alias roomdb.Alias) {
 	var resp = aliasJSONResponse{
-		Status:    "successful",
-		RoomID:    json.netInfo.RoomID.Ref(),
-		Address:   json.netInfo.MultiserverAddress(),
-		Alias:     alias.Name,
-		UserID:    alias.Feed.Ref(),
-		Signature: base64.StdEncoding.EncodeToString(alias.Signature),
+		Status:             "successful",
+		RoomID:             json.netInfo.RoomID.Ref(),
+		MultiserverAddress: json.netInfo.MultiserverAddress(),
+		Alias:              alias.Name,
+		UserID:             alias.Feed.Ref(),
+		Signature:          base64.StdEncoding.EncodeToString(alias.Signature),
 	}
 	json.enc.Encode(resp)
 }

--- a/web/handlers/aliases_test.go
+++ b/web/handlers/aliases_test.go
@@ -65,6 +65,7 @@ func TestAliasResolve(t *testing.T) {
 	r.NoError(err)
 	a.Equal(testAlias.Signature, sigData)
 	a.Equal(ts.NetworkInfo.RoomID.Ref(), params.Get("roomId"))
+	a.Equal(ts.NetworkInfo.MultiserverAddress(), params.Get("multiserverAddress"))
 
 	// now as JSON
 	jsonURL, err := routes.Get(router.CompleteAliasResolve).URL("alias", testAlias.Name)
@@ -86,4 +87,5 @@ func TestAliasResolve(t *testing.T) {
 	a.Equal(testAlias.Signature, sigData2)
 	a.Equal(testAlias.Feed.Ref(), ar.UserID, "wrong user feed on response")
 	a.Equal(ts.NetworkInfo.RoomID.Ref(), ar.RoomID, "wrong room feed on response")
+	a.Equal(ts.NetworkInfo.MultiserverAddress(), ar.MultiserverAddress)
 }


### PR DESCRIPTION
Fixes #183. Turned out the field itself was present, just needed a rename from `address` to `multiserverAddress`. And a few more tests.