### PR TITLE
dont allow upercase chars in aliases (fix #192)

### DIFF
--- a/internal/aliases/names.go
+++ b/internal/aliases/names.go
@@ -2,16 +2,12 @@
 
 package aliases
 
-import (
-	"fmt"
-)
-
 // IsValid decides whether an alias is okay for use or not.
 // The room spec defines it as _labels valid under RFC 1035_ ( https://ssb-ngi-pointer.github.io/rooms2/#alias-string )
 // but that can be mostly any string since DNS is a 8bit binary protocol,
 // as long as it's shorter then 63 charachters.
 //
-// Right now it's pretty basic set of characters (a-z, A-Z, 0-9).
+// Right now it's pretty basic set of characters (a-z, 0-9).
 // In theory we could be more liberal but there is a bunch of stuff to figure out,
 // like homograph attacks (https://en.wikipedia.org/wiki/IDN_homograph_attack),
 // if we would decide to allow full utf8 unicode.
@@ -30,11 +26,6 @@ func IsValid(alias string) bool {
 			continue
 		}
 
-		if char >= 'A' && char <= 'Z' { // is an ASCII upper-case char between a and z
-			continue
-		}
-
-		fmt.Println("found", char)
 		valid = false
 		break
 	}

--- a/internal/aliases/names_test.go
+++ b/internal/aliases/names_test.go
@@ -20,6 +20,8 @@ func TestIsValid(t *testing.T) {
 		{"no.dots", false},
 		{"#*!(! nope", false},
 
+		{"NoUpperCase", false},
+
 		// too long
 		{"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", false},
 	}


### PR DESCRIPTION
Thanks for testing @soapdog!

Using strings with UpperCase doesn't work in Firefox because turns it into `uppercase.$domain` which then is not found because it matches case sensitive...