### PR TITLE
Privacy mode tests 💯 💯 

### DIFF
--- a/roomsrv/init_network.go
+++ b/roomsrv/init_network.go
@@ -35,7 +35,7 @@ func (s *Server) initNetwork() error {
 
 		// if privacy mode is restricted, deny connections from non-members
 		if pm == roomdb.ModeRestricted {
-			if _, err := s.authorizer.GetByFeed(s.rootCtx, *remote); err != nil {
+			if _, err := s.Members.GetByFeed(s.rootCtx, *remote); err != nil {
 				return nil, fmt.Errorf("access restricted to members")
 			}
 		}

--- a/roomsrv/server.go
+++ b/roomsrv/server.go
@@ -61,8 +61,6 @@ type Server struct {
 	public typemux.HandlerMux
 	master typemux.HandlerMux
 
-	authorizer roomdb.MembersService
-
 	StateManager *roomstate.Manager
 
 	Members    roomdb.MembersService
@@ -89,7 +87,6 @@ func New(
 	opts ...Option,
 ) (*Server, error) {
 	var s Server
-	s.authorizer = membersdb
 
 	s.Members = membersdb
 	s.DeniedKeys = deniedkeysdb

--- a/web/errors/errhandler.go
+++ b/web/errors/errhandler.go
@@ -34,7 +34,7 @@ func (eh *ErrorHandler) SetRenderer(r *render.Renderer) {
 
 func (eh *ErrorHandler) Handle(rw http.ResponseWriter, req *http.Request, code int, err error) {
 	log := logging.FromContext(req.Context())
-	level.Error(log).Log("event", "handling error","path", req.URL.Path, "err",err)
+	level.Error(log).Log("event", "handling error", "path", req.URL.Path, "err", err)
 	var redirectErr ErrRedirect
 	if errors.As(err, &redirectErr) {
 		if redirectErr.Reason != nil {

--- a/web/handlers/admin/aliases_test.go
+++ b/web/handlers/admin/aliases_test.go
@@ -53,7 +53,13 @@ func TestAliasesRevoke(t *testing.T) {
 	urlRevoke := ts.URLTo(router.AdminAliasesRevoke)
 	overviewURL := ts.URLTo(router.AdminMembersOverview)
 
+	aliasEntry := roomdb.Alias{
+		ID:   ts.User.ID,
+		Feed: ts.User.PubKey,
+		Name: "Blobby",
+	}
 	ts.AliasesDB.RevokeReturns(nil)
+	ts.AliasesDB.ResolveReturns(aliasEntry, nil)
 
 	addVals := url.Values{"name": []string{"the-name"}}
 	rec := ts.Client.PostForm(urlRevoke, addVals)

--- a/web/handlers/admin/invites.go
+++ b/web/handlers/admin/invites.go
@@ -76,11 +76,11 @@ func (h invitesHandler) create(w http.ResponseWriter, req *http.Request) (interf
 	case roomdb.ModeOpen:
 	case roomdb.ModeCommunity:
 		if member.Role == roomdb.RoleUnknown {
-			return nil, fmt.Errorf("warning: member with unknown role tried to create an invite")
+			return nil, weberrors.ErrNotAuthorized
 		}
 	case roomdb.ModeRestricted:
 		if member.Role == roomdb.RoleMember || member.Role == roomdb.RoleUnknown {
-			return nil, fmt.Errorf("warning: non-admin/mod user tried to create an invite")
+			return nil, weberrors.ErrNotAuthorized
 		}
 	}
 

--- a/web/handlers/admin/invites_test.go
+++ b/web/handlers/admin/invites_test.go
@@ -159,8 +159,7 @@ func TestInvitesCreate(t *testing.T) {
 			_, userID := ts.InvitesDB.CreateArgsForCall(totalCreateCallCount - 1)
 			a.EqualValues(ts.User.ID, userID)
 		} else {
-			// TODO: status should be http.StatusForbidden? see invites.go:79
-			a.Equal(http.StatusInternalServerError, rec.Code)
+			a.Equal(http.StatusForbidden, rec.Code)
 			r.Equal(totalCreateCallCount, ts.InvitesDB.CreateCallCount())
 		}
 		return rec

--- a/web/handlers/admin/notices_test.go
+++ b/web/handlers/admin/notices_test.go
@@ -89,7 +89,7 @@ func TestNoticeAddLanguageOnlyAllowsPost(t *testing.T) {
 	// verify that a GET request is no bueno
 	u := ts.URLTo(router.AdminNoticeAddTranslation, "name", roomdb.NoticeNews.String())
 	_, resp := ts.Client.GetHTML(u)
-	a.Equal(http.StatusMethodNotAllowed, resp.Code, "GET should not be allowed for this route")
+	a.Equal(http.StatusBadRequest, resp.Code, "GET should not be allowed for this route")
 
 	// next up, we verify that a correct POST request actually works:
 	id := []string{"1"}

--- a/web/handlers/admin/setup_test.go
+++ b/web/handlers/admin/setup_test.go
@@ -99,6 +99,10 @@ func newSession(t *testing.T) *testSession {
 	ts.User = roomdb.Member{
 		ID:   1234,
 		Role: roomdb.RoleModerator,
+		PubKey: refs.FeedRef{
+			ID:   bytes.Repeat([]byte("0"), 32),
+			Algo: "ed25519",
+		},
 	}
 
 	testPath := filepath.Join("testrun", t.Name())
@@ -174,7 +178,7 @@ func newSession(t *testing.T) *testSession {
 		},
 	)
 
-	handler = members.MiddlewareForTests(ts.User)(handler)
+	handler = members.MiddlewareForTests(&ts.User)(handler)
 
 	ts.Mux = http.NewServeMux()
 	ts.Mux.Handle("/", handler)

--- a/web/handlers/admin/setup_test.go
+++ b/web/handlers/admin/setup_test.go
@@ -56,6 +56,14 @@ type testSession struct {
 	RoomState *roomstate.Manager
 }
 
+var pubKeyCount byte
+
+func generatePubKey() refs.FeedRef {
+	pk := refs.FeedRef{Algo: "ed25519", ID: bytes.Repeat([]byte{pubKeyCount}, 32)}
+	pubKeyCount++
+	return pk
+}
+
 func newSession(t *testing.T) *testSession {
 	var ts testSession
 
@@ -76,7 +84,7 @@ func newSession(t *testing.T) *testSession {
 
 	ts.netInfo = network.ServerEndpointDetails{
 		Domain: randutil.String(10),
-		RoomID: refs.FeedRef{Algo: "ed25519", ID: bytes.Repeat([]byte{0}, 32)},
+		RoomID: generatePubKey(),
 
 		UseSubdomainForAliases: true,
 	}
@@ -97,12 +105,9 @@ func newSession(t *testing.T) *testSession {
 
 	// fake user
 	ts.User = roomdb.Member{
-		ID:   1234,
-		Role: roomdb.RoleModerator,
-		PubKey: refs.FeedRef{
-			ID:   bytes.Repeat([]byte("0"), 32),
-			Algo: "ed25519",
-		},
+		ID:     1234,
+		Role:   roomdb.RoleModerator,
+		PubKey: generatePubKey(),
 	}
 
 	testPath := filepath.Join("testrun", t.Name())

--- a/web/handlers/aliases_test.go
+++ b/web/handlers/aliases_test.go
@@ -88,4 +88,11 @@ func TestAliasResolve(t *testing.T) {
 	a.Equal(testAlias.Feed.Ref(), ar.UserID, "wrong user feed on response")
 	a.Equal(ts.NetworkInfo.RoomID.Ref(), ar.RoomID, "wrong room feed on response")
 	a.Equal(ts.NetworkInfo.MultiserverAddress(), ar.MultiserverAddress)
+
+	/* alias resolving should not work for restricted rooms */
+	ts.ConfigDB.GetPrivacyModeReturns(roomdb.ModeRestricted, nil)
+	htmlURL, err = routes.Get(router.CompleteAliasResolve).URL("alias", testAlias.Name)
+	r.NoError(err)
+	html, resp = ts.Client.GetHTML(htmlURL)
+	a.Equal(http.StatusInternalServerError, resp.Code)
 }

--- a/web/members/testing.go
+++ b/web/members/testing.go
@@ -13,10 +13,10 @@ import (
 // This is part of testing.go because we need to use roomMemberContextKey, which shouldn't be exported either.
 // TODO: could be protected with an extra build tag.
 // (Sadly +build test does not exist https://github.com/golang/go/issues/21360 )
-func MiddlewareForTests(m roomdb.Member) func(http.Handler) http.Handler {
+func MiddlewareForTests(m *roomdb.Member) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			ctx := context.WithValue(req.Context(), roomMemberContextKey, &m)
+			ctx := context.WithValue(req.Context(), roomMemberContextKey, m)
 			next.ServeHTTP(w, req.WithContext(ctx))
 		})
 	}


### PR DESCRIPTION
This PR implements most of the missing tests of #96; closes #96.

Not implemented: tests for the open mode, because we're lacking anything meaningful on that front as of yet :)

```
YUP     member cannot create invite
YUP     moderator can create invite
YUP     admin can create invite
YUP     non-members cannot connect to room / finish connection establishment / query room for others??
YUP     alias resolving should not work (returns error if attempted)

community mode:
YUP     member can create invite
YUP     moderator can create invite
YUP     admin can create invite
YUP     non-members can connect to room / conn establishment works

open mode:
can't really test, as we don't have this functinality in other places?
```