### PR TITLE
have a clear error on taken aliases

### DIFF
--- a/muxrpc/handlers/alias/handler.go
+++ b/muxrpc/handlers/alias/handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -99,6 +100,10 @@ func (h Handler) Register(ctx context.Context, req *muxrpc.Request) (interface{}
 
 	err = h.db.Register(ctx, confirmation.Alias, confirmation.UserID, confirmation.Signature)
 	if err != nil {
+		var takenErr roomdb.ErrAliasTaken
+		if errors.As(err, &takenErr) {
+			return nil, takenErr
+		}
 		return nil, fmt.Errorf("registerAlias: could not register alias: %w", err)
 	}
 

--- a/muxrpc/test/go/alias_test.go
+++ b/muxrpc/test/go/alias_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"net/url"
 	"testing"
 	"time"
@@ -104,6 +105,14 @@ func TestAliasRegister(t *testing.T) {
 	a.True(confirmation.UserID.Equal(&bobsKey.Feed))
 
 	t.Log("alias stored")
+
+	// check taken error
+	err = clientForServer.Async(ctx, &registerResponse, muxrpc.TypeString, muxrpc.Method{"room", "registerAlias"}, "bob", sig)
+	r.Error(err)
+
+	var callErr *muxrpc.CallError
+	r.True(errors.As(err, &callErr), "expected a call error: %T", err)
+	r.Equal(`alias ("bob") is already taken`, callErr.Message)
 
 	for _, bot := range theBots {
 		bot.srv.Shutdown()

--- a/roomdb/sqlite/aliases.go
+++ b/roomdb/sqlite/aliases.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 
 	"github.com/friendsofgo/errors"
+	"github.com/mattn/go-sqlite3"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 
@@ -93,7 +94,10 @@ func (a Aliases) Register(ctx context.Context, alias string, userFeed refs.FeedR
 		newEntry.Signature = signature
 
 		err = newEntry.Insert(ctx, tx, boil.Infer())
-
+		var sqlErr sqlite3.Error
+		if errors.As(err, &sqlErr) && sqlErr.ExtendedCode == sqlite3.ErrConstraintUnique {
+			return roomdb.ErrAliasTaken{Name: alias}
+		}
 		return err
 	})
 }

--- a/roomdb/types.go
+++ b/roomdb/types.go
@@ -31,7 +31,7 @@ type ErrAliasTaken struct {
 }
 
 func (e ErrAliasTaken) Error() string {
-	return fmt.Sprintf("roomdb: alias (%q) is already taken", e.Name)
+	return fmt.Sprintf("alias (%q) is already taken", e.Name)
 }
 
 // Member holds all the information an internal user of the room has.

--- a/roomdb/types.go
+++ b/roomdb/types.go
@@ -26,6 +26,14 @@ type Alias struct {
 	Signature []byte
 }
 
+type ErrAliasTaken struct {
+	Name string
+}
+
+func (e ErrAliasTaken) Error() string {
+	return fmt.Sprintf("roomdb: alias (%q) is already taken", e.Name)
+}
+
 // Member holds all the information an internal user of the room has.
 type Member struct {
 	ID      int64


### PR DESCRIPTION
fixes #194 - It will now show as:

> transaction failed, rolling back: roomdb: alias (\"thealias\") is already taken`