### PR TITLE
set muxrpc header flag correctly

### DIFF
--- a/muxrpc/handlers/tunnel/server/attendants.go
+++ b/muxrpc/handlers/tunnel/server/attendants.go
@@ -51,6 +51,7 @@ func (h *Handler) attendants(ctx context.Context, req *muxrpc.Request, snk *muxr
 	h.state.AddEndpoint(*peer, req.Endpoint())
 
 	// send the current state
+	snk.SetEncoding(muxrpc.TypeJSON)
 	err = json.NewEncoder(snk).Encode(AttendantsInitialState{
 		Type: "state",
 		IDs:  h.state.ListAsRefs(),


### PR DESCRIPTION
Without this it defaults to bytes and the first/initial state event is transfer without flags and perceived as `Buffer()` in JS.