### PR TITLE
Release v2.0.6

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,7 +43,7 @@ import (
 
 // Version and Build are set by ldflags
 var (
-	version = "v2.0.6-snapshot"
+	version = "v2.0.6"
 	commit  = "unset"
 )
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,7 +43,7 @@ import (
 
 // Version and Build are set by ldflags
 var (
-	version = "v2.0.6"
+	version = "v2.0.7-snapshot"
 	commit  = "unset"
 )
 


### PR DESCRIPTION
With this PR I propose to make 404406e the next patch release. If we merge this I will create a tag and make the `.deb` file.

It just contains #238 but it feels like an important enough fix.