### PR TITLE
Exclude revoked invites in dashboard invite count (#177)

### DIFF
--- a/roomdb/interface.go
+++ b/roomdb/interface.go
@@ -161,6 +161,9 @@ type InvitesService interface {
 	// Count returns the total number of invites.
 	Count(context.Context) (uint, error)
 
+	// CountActive returns the total number of active invites.
+	CountActive(context.Context) (uint, error)
+
 	// Revoke removes a active invite and invalidates it for future use.
 	Revoke(ctx context.Context, id int64) error
 }

--- a/roomdb/interface.go
+++ b/roomdb/interface.go
@@ -158,11 +158,8 @@ type InvitesService interface {
 	// List returns a list of all the valid invites
 	List(ctx context.Context) ([]Invite, error)
 
-	// Count returns the total number of invites.
-	Count(context.Context) (uint, error)
-
-	// CountActive returns the total number of active invites.
-	CountActive(context.Context) (uint, error)
+	// Count returns the total number of invites, optionally excluding inactive invites
+	Count(ctx context.Context, onlyActive bool) (uint, error)
 
 	// Revoke removes a active invite and invalidates it for future use.
 	Revoke(ctx context.Context, id int64) error

--- a/roomdb/mockdb/invites.go
+++ b/roomdb/mockdb/invites.go
@@ -25,10 +25,11 @@ type FakeInvitesService struct {
 		result1 roomdb.Invite
 		result2 error
 	}
-	CountStub        func(context.Context) (uint, error)
+	CountStub        func(context.Context, bool) (uint, error)
 	countMutex       sync.RWMutex
 	countArgsForCall []struct {
 		arg1 context.Context
+		arg2 bool
 	}
 	countReturns struct {
 		result1 uint
@@ -175,18 +176,19 @@ func (fake *FakeInvitesService) ConsumeReturnsOnCall(i int, result1 roomdb.Invit
 	}{result1, result2}
 }
 
-func (fake *FakeInvitesService) Count(arg1 context.Context) (uint, error) {
+func (fake *FakeInvitesService) Count(arg1 context.Context, arg2 bool) (uint, error) {
 	fake.countMutex.Lock()
 	ret, specificReturn := fake.countReturnsOnCall[len(fake.countArgsForCall)]
 	fake.countArgsForCall = append(fake.countArgsForCall, struct {
 		arg1 context.Context
-	}{arg1})
+		arg2 bool
+	}{arg1, arg2})
 	stub := fake.CountStub
 	fakeReturns := fake.countReturns
-	fake.recordInvocation("Count", []interface{}{arg1})
+	fake.recordInvocation("Count", []interface{}{arg1, arg2})
 	fake.countMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -200,17 +202,17 @@ func (fake *FakeInvitesService) CountCallCount() int {
 	return len(fake.countArgsForCall)
 }
 
-func (fake *FakeInvitesService) CountCalls(stub func(context.Context) (uint, error)) {
+func (fake *FakeInvitesService) CountCalls(stub func(context.Context, bool) (uint, error)) {
 	fake.countMutex.Lock()
 	defer fake.countMutex.Unlock()
 	fake.CountStub = stub
 }
 
-func (fake *FakeInvitesService) CountArgsForCall(i int) context.Context {
+func (fake *FakeInvitesService) CountArgsForCall(i int) (context.Context, bool) {
 	fake.countMutex.RLock()
 	defer fake.countMutex.RUnlock()
 	argsForCall := fake.countArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeInvitesService) CountReturns(result1 uint, result2 error) {

--- a/roomdb/sqlite/invites.go
+++ b/roomdb/sqlite/invites.go
@@ -250,18 +250,12 @@ func (i Invites) List(ctx context.Context) ([]roomdb.Invite, error) {
 	return invs, nil
 }
 
-func (i Invites) Count(ctx context.Context) (uint, error) {
-	count, err := models.Invites().Count(ctx, i.db)
-	if err != nil {
-		return 0, err
+func (i Invites) Count(ctx context.Context, onlyActive bool) (uint, error) {
+	queryMod := qm.Where("1")
+	if onlyActive {
+		queryMod = qm.Where("active = true")
 	}
-	return uint(count), nil
-}
-
-func (i Invites) CountActive(ctx context.Context) (uint, error) {
-	count, err := models.Invites(
-		qm.Where("active = true"),
-	).Count(ctx, i.db)
+	count, err := models.Invites(queryMod).Count(ctx, i.db)
 	if err != nil {
 		return 0, err
 	}

--- a/roomdb/sqlite/invites.go
+++ b/roomdb/sqlite/invites.go
@@ -258,6 +258,16 @@ func (i Invites) Count(ctx context.Context) (uint, error) {
 	return uint(count), nil
 }
 
+func (i Invites) CountActive(ctx context.Context) (uint, error) {
+	count, err := models.Invites(
+		qm.Where("active = true"),
+	).Count(ctx, i.db)
+	if err != nil {
+		return 0, err
+	}
+	return uint(count), nil
+}
+
 // Revoke removes a active invite and invalidates it for future use.
 func (i Invites) Revoke(ctx context.Context, id int64) error {
 	return transact(i.db, func(tx *sql.Tx) error {

--- a/web/handlers/admin/dashboard.go
+++ b/web/handlers/admin/dashboard.go
@@ -77,7 +77,7 @@ func (h dashboardHandler) overview(w http.ResponseWriter, req *http.Request) (in
 		return nil, fmt.Errorf("failed to count members: %w", err)
 	}
 
-	inviteCount, err := h.dbs.Invites.CountActive(ctx)
+	inviteCount, err := h.dbs.Invites.Count(ctx, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count active invites: %w", err)
 	}

--- a/web/handlers/admin/dashboard.go
+++ b/web/handlers/admin/dashboard.go
@@ -77,9 +77,9 @@ func (h dashboardHandler) overview(w http.ResponseWriter, req *http.Request) (in
 		return nil, fmt.Errorf("failed to count members: %w", err)
 	}
 
-	inviteCount, err := h.dbs.Invites.Count(ctx)
+	inviteCount, err := h.dbs.Invites.CountActive(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to count invites: %w", err)
+		return nil, fmt.Errorf("failed to count active invites: %w", err)
 	}
 
 	deniedCount, err := h.dbs.DeniedKeys.Count(ctx)


### PR DESCRIPTION
This addresses #177. I'm not too familiar with Go traditions and SQLBoiler -- is the present approach with Invites.CountActive appropriate, or would adding a parameter to Invites.Count be preferred?

I'm yet to update the Invites mock and write a corresponding unit test.

Thanks a lot for your ssb work!