### PR TITLE
fix support for SSB URIs on Android Chrome

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mattevans/pwned-passwords v0.3.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0
+	github.com/mileusna/useragent v1.0.2 // indirect
 	github.com/nicksnyder/go-i18n/v2 v2.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/rubenv/sql-migrate v0.0.0-20200616145509-8d140a17f351

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0 h1:8E6DrFvII6QR4eJ3PkFvV+lc03P+2qwqTPLm1ax7694=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0/go.mod h1:fcEyUyXZXoV4Abw8DX0t7wyL8mCDxXyU4iAFZfT3IHw=
+github.com/mileusna/useragent v1.0.2 h1:DgVKtiPnjxlb73z9bCwgdUvU2nQNQ97uhgfO8l9uz/w=
+github.com/mileusna/useragent v1.0.2/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/miolini/datacounter v0.0.0-20171104152933-fd4e42a1d5e0/go.mod h1:P6fDJzlxN+cWYR09KbE9/ta+Y6JofX9tAUhJpWkWPaM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/web/handlers/aliases.go
+++ b/web/handlers/aliases.go
@@ -13,8 +13,8 @@ import (
 	"net/http"
 	"net/url"
 
-	ua "github.com/mileusna/useragent"
 	"github.com/gorilla/mux"
+	ua "github.com/mileusna/useragent"
 	"go.mindeco.de/http/render"
 
 	"github.com/ssb-ngi-pointer/go-ssb-room/v2/internal/aliases"
@@ -173,7 +173,7 @@ func (html aliasHTMLResponder) SendConfirmation(alias roomdb.Alias) {
 			Scheme:   "intent",
 			Opaque:   "//experimental",
 			RawQuery: queryParams.Encode(),
-			Fragment: "Intent;scheme=ssb;package=se.manyver;end;",
+			Fragment: "Intent;scheme=ssb;end;",
 		}
 	}
 

--- a/web/handlers/aliases_test.go
+++ b/web/handlers/aliases_test.go
@@ -158,5 +158,5 @@ func TestAliasResolveOnAndroidChrome(t *testing.T) {
 	a.Equal(ts.NetworkInfo.MultiserverAddress(), params.Get("multiserverAddress"))
 
 	frag := aliasURI.Fragment
-	a.Equal("Intent;scheme=ssb;package=se.manyver;end;", frag)
+	a.Equal("Intent;scheme=ssb;end;", frag)
 }

--- a/web/handlers/aliases_test.go
+++ b/web/handlers/aliases_test.go
@@ -100,3 +100,63 @@ func TestAliasResolve(t *testing.T) {
 	html, resp = ts.Client.GetHTML(htmlURL)
 	a.Equal(http.StatusInternalServerError, resp.Code)
 }
+
+func TestAliasResolveOnAndroidChrome(t *testing.T) {
+	ts := setup(t)
+
+	a := assert.New(t)
+	r := require.New(t)
+
+	var testAlias = roomdb.Alias{
+		ID:   54321,
+		Name: "test-name",
+		Feed: refs.FeedRef{
+			ID:   bytes.Repeat([]byte{'F'}, 32),
+			Algo: "test",
+		},
+		Signature: bytes.Repeat([]byte{'S'}, 32),
+	}
+	ts.AliasesDB.ResolveReturns(testAlias, nil)
+
+	// Mimic Android Chrome
+	var uaHeader = make(http.Header)
+	uaHeader.Set("User-Agent", "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MOB30H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36")
+	ts.Client.SetHeaders(uaHeader)
+
+	// to construct the /alias/{name} url we need to bypass urlTo
+	// (which builds ?alias=name)
+	routes := router.CompleteApp()
+
+	// default is HTML
+
+	htmlURL, err := routes.Get(router.CompleteAliasResolve).URL("alias", testAlias.Name)
+	r.NoError(err)
+
+	t.Log("resolving", htmlURL.String())
+	html, resp := ts.Client.GetHTML(htmlURL)
+	a.Equal(http.StatusOK, resp.Code)
+
+	a.Equal(testAlias.Name, html.Find("title").Text())
+
+	// ssb-uri in href
+	aliasHref, ok := html.Find("#alias-uri").Attr("href")
+	a.True(ok)
+	aliasURI, err := url.Parse(aliasHref)
+	r.NoError(err)
+
+	a.Equal("intent", aliasURI.Scheme)
+	a.Equal("experimental", aliasURI.Host)
+
+	params := aliasURI.Query()
+	a.Equal("consume-alias", params.Get("action"))
+	a.Equal(testAlias.Name, params.Get("alias"))
+	a.Equal(testAlias.Feed.Ref(), params.Get("userId"))
+	sigData, err := base64.StdEncoding.DecodeString(params.Get("signature"))
+	r.NoError(err)
+	a.Equal(testAlias.Signature, sigData)
+	a.Equal(ts.NetworkInfo.RoomID.Ref(), params.Get("roomId"))
+	a.Equal(ts.NetworkInfo.MultiserverAddress(), params.Get("multiserverAddress"))
+
+	frag := aliasURI.Fragment
+	a.Equal("Intent;scheme=ssb;package=se.manyver;end;", frag)
+}

--- a/web/handlers/auth/withssb.go
+++ b/web/handlers/auth/withssb.go
@@ -381,7 +381,7 @@ func (h WithSSBHandler) serverInitiated(sc string, userAgent string) (templateDa
 			Scheme:   "intent",
 			Opaque:   "//experimental",
 			RawQuery: queryParams.Encode(),
-			Fragment: "Intent;scheme=ssb;package=se.manyver;end;",
+			Fragment: "Intent;scheme=ssb;end;",
 		}
 	}
 

--- a/web/handlers/auth/withssb.go
+++ b/web/handlers/auth/withssb.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
-	ua "github.com/mileusna/useragent"
 	"github.com/skip2/go-qrcode"
 	"go.cryptoscope.co/muxrpc/v2"
 	"go.mindeco.de/http/render"
@@ -373,18 +372,6 @@ func (h WithSSBHandler) serverInitiated(sc string, userAgent string) (templateDa
 	startAuthURI.Opaque = "experimental"
 	startAuthURI.RawQuery = queryParams.Encode()
 
-	// Special treatment for Android Chrome for issue #135
-	// https://github.com/ssb-ngi-pointer/go-ssb-room/issues/135
-	browser := ua.Parse(userAgent)
-	if browser.IsAndroid() && browser.IsChrome() {
-		startAuthURI = url.URL{
-			Scheme:   "intent",
-			Opaque:   "//experimental",
-			RawQuery: queryParams.Encode(),
-			Fragment: "Intent;scheme=ssb;end;",
-		}
-	}
-
 	var qrURI string
 	if !isSolvingRemotely {
 		urlTo := web.NewURLTo(router.Auth(h.router), h.netInfo)
@@ -416,7 +403,7 @@ func (h WithSSBHandler) serverInitiated(sc string, userAgent string) (templateDa
 	// template.URL signals the template engine that those aren't fishy and from a trusted source
 
 	data := templateData{
-		SSBURI:            template.URL(startAuthURI.String()),
+		SSBURI:            template.URL(web.StringifySSBURI(&startAuthURI, userAgent)),
 		QRCodeURI:         template.URL(qrURI),
 		IsSolvingRemotely: isSolvingRemotely,
 

--- a/web/handlers/auth/withssb.go
+++ b/web/handlers/auth/withssb.go
@@ -368,9 +368,6 @@ func (h WithSSBHandler) serverInitiated(sc string, userAgent string) (templateDa
 		Opaque:   "experimental",
 		RawQuery: queryParams.Encode(),
 	}
-	startAuthURI.Scheme = "ssb"
-	startAuthURI.Opaque = "experimental"
-	startAuthURI.RawQuery = queryParams.Encode()
 
 	var qrURI string
 	if !isSolvingRemotely {

--- a/web/handlers/auth_test.go
+++ b/web/handlers/auth_test.go
@@ -598,5 +598,5 @@ func TestAuthWithSSBServerOnAndroidChrome(t *testing.T) {
 	a.Equal("start-http-auth", qry.Get("action"))
 
 	frag := parsedURI.Fragment
-	a.Equal("Intent;scheme=ssb;package=se.manyver;end;", frag)
+	a.Equal("Intent;scheme=ssb;end;", frag)
 }

--- a/web/handlers/invites.go
+++ b/web/handlers/invites.go
@@ -49,9 +49,9 @@ func (h inviteHandler) buildJoinRoomURI(token string, userAgent string) template
 	queryVals.Set("postTo", submissionURL.String())
 
 	joinRoomURI := url.URL{
-		Scheme:  "ssb",
-		Opaque:  "experimental",
-		RawPath: queryVals.Encode(),
+		Scheme:   "ssb",
+		Opaque:   "experimental",
+		RawQuery: queryVals.Encode(),
 	}
 
 	// Special treatment for Android Chrome for issue #135

--- a/web/handlers/invites.go
+++ b/web/handlers/invites.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/csrf"
-	ua "github.com/mileusna/useragent"
 	"github.com/skip2/go-qrcode"
 	"go.mindeco.de/http/render"
 	"go.mindeco.de/log/level"
@@ -54,19 +53,7 @@ func (h inviteHandler) buildJoinRoomURI(token string, userAgent string) template
 		RawQuery: queryVals.Encode(),
 	}
 
-	// Special treatment for Android Chrome for issue #135
-	// https://github.com/ssb-ngi-pointer/go-ssb-room/issues/135
-	browser := ua.Parse(userAgent)
-	if browser.IsAndroid() && browser.IsChrome() {
-		joinRoomURI = url.URL{
-			Scheme:   "intent",
-			Opaque:   "//experimental",
-			RawQuery: queryVals.Encode(),
-			Fragment: "Intent;scheme=ssb;end;",
-		}
-	}
-
-	return template.URL(joinRoomURI.String())
+	return template.URL(web.StringifySSBURI(&joinRoomURI, userAgent))
 }
 
 // switch between JSON and HTML responses

--- a/web/handlers/invites.go
+++ b/web/handlers/invites.go
@@ -62,7 +62,7 @@ func (h inviteHandler) buildJoinRoomURI(token string, userAgent string) template
 			Scheme:   "intent",
 			Opaque:   "//experimental",
 			RawQuery: queryVals.Encode(),
-			Fragment: "Intent;scheme=ssb;package=se.manyver;end;",
+			Fragment: "Intent;scheme=ssb;end;",
 		}
 	}
 

--- a/web/handlers/invites_test.go
+++ b/web/handlers/invites_test.go
@@ -107,7 +107,7 @@ func TestInviteShowAcceptForm(t *testing.T) {
 	})
 }
 
-func TestInviteShowAcceptFormOnAndroid(t *testing.T) {
+func TestInviteShowAcceptFormOnAndroidChrome(t *testing.T) {
 	ts := setup(t)
 
 	a, r := assert.New(t), require.New(t)

--- a/web/handlers/invites_test.go
+++ b/web/handlers/invites_test.go
@@ -158,7 +158,7 @@ func TestInviteShowAcceptFormOnAndroid(t *testing.T) {
 	a.Equal(expectedConsumeInviteURL.String(), postTo)
 
 	frag := joinURI.Fragment
-	a.Equal("Intent;scheme=ssb;package=se.manyver;end;", frag)
+	a.Equal("Intent;scheme=ssb;end;", frag)
 }
 
 func TestInviteConsumeInviteHTTP(t *testing.T) {


### PR DESCRIPTION
Finally found a fix for #135 . TL;DR is that on Android Chrome we have to do `intent://PATH?QUERYPARAMS#Intent;scheme=ssb;end;` instead of `ssb://PATH?QUERYPARAMS`. See [Android Chrome docs](https://developer.chrome.com/docs/multidevice/android/intents/). So we discover the user agent and trigger this fix only for Android Chrome.

:heavy_check_mark: Unit tests added.

:heavy_check_mark: Tested end-to-end with a phone running Manyverse (tested both Android Firefox and Android Chrome).