### PR TITLE
Fix alias not being displayed on the invites page

### DIFF
--- a/roomdb/sqlite/invites.go
+++ b/roomdb/sqlite/invites.go
@@ -228,6 +228,7 @@ func (i Invites) List(ctx context.Context) ([]roomdb.Invite, error) {
 		entries, err := models.Invites(
 			qm.Where("active = true"),
 			qm.Load("CreatedByMember"),
+			qm.Load("CreatedByMember.Aliases"),
 		).All(ctx, tx)
 		if err != nil {
 			return err

--- a/roomdb/sqlite/invites_test.go
+++ b/roomdb/sqlite/invites_test.go
@@ -59,6 +59,11 @@ func TestInvites(t *testing.T) {
 	mid, err := db.Members.Add(ctx, invitingMember, roomdb.RoleModerator)
 	require.NoError(t, err, "failed to create test user")
 
+	aliasString := "alias"
+
+	err = db.Aliases.Register(ctx, aliasString, invitingMember, []byte("signature"))
+	require.NoError(t, err, "failed to create an alias for the test user")
+
 	t.Run("simple create and consume", func(t *testing.T) {
 		r := require.New(t)
 
@@ -76,6 +81,8 @@ func TestInvites(t *testing.T) {
 		r.Len(lst, 1, "expected 1 invite")
 
 		r.True(lst[0].CreatedAt.After(before), "expected CreatedAt to be after the start marker")
+		r.NotEmpty(lst[0].CreatedBy.Aliases, "expected aliases of the user to be populated")
+		r.Equal(aliasString, lst[0].CreatedBy.Aliases[0].Name, "alias name should be populated")
 
 		_, nope := db.Members.GetByFeed(ctx, newMember)
 		r.Error(nope, "expected feed to not yet be on the allow list")

--- a/web/handlers/admin/invites_test.go
+++ b/web/handlers/admin/invites_test.go
@@ -64,10 +64,16 @@ func TestInvitesOverview(t *testing.T) {
 	elems := html.Find(trSelector)
 	a.EqualValues(1, elems.Length()/2, "wrong number of entries on the table (signular)")
 
-	// check for link to remove confirm link
-	link, yes := elems.Find("a").Attr("href")
+	// check for the link to member details
+	link, yes := elems.Find("a").Eq(0).Attr("href")
 	a.True(yes, "a-tag has href attribute")
-	wantURL := ts.URLTo(router.AdminInvitesRevokeConfirm, "id", 666)
+	wantURL := ts.URLTo(router.AdminMemberDetails, "id", testUser.ID)
+	a.Equal(wantURL.String(), link)
+
+	// check for link to remove confirm link
+	link, yes = elems.Find("a").Eq(1).Attr("href")
+	a.True(yes, "a-tag has href attribute")
+	wantURL = ts.URLTo(router.AdminInvitesRevokeConfirm, "id", 666)
 	a.Equal(wantURL.String(), link)
 
 	testInviteButtonDisabled := func(shouldBeDisabled bool) {

--- a/web/templates/admin/invite-list.tmpl
+++ b/web/templates/admin/invite-list.tmpl
@@ -75,11 +75,13 @@ SPDX-License-Identifier: CC-BY-4.0
           </div>
         </td>
         <td class="w-6/12 px-2">
-          {{if eq $creatorIsAlias true}}
-            {{$creator}}
-          {{else}}
-            <span class="font-mono text-sm w-32 truncate block">{{$creator}}</span>
-          {{end}}
+          <a href="{{urlTo "admin:member:details" "id" .CreatedBy.ID}}">
+            {{if eq $creatorIsAlias true}}
+              {{$creator}}
+            {{else}}
+              <span class="font-mono text-sm w-32 truncate block">{{$creator}}</span>
+            {{end}}
+          </a>
         </td>
         <td class="w-3/12 pl-2 pr-3 text-right">
         {{ if or member_is_elevated $hasCreatedInvite }}


### PR DESCRIPTION
Reading the template of the invites page it was the intention of the
author to display the aliases instead of user refs if they are
available. The code loading the invites wasn't properly loading the
aliases of the useres who created them though always leading to this
data not being populated. This fix populates the aliases when listing
invites.

Additionally turned the invite author field into a link. This requires
some extra styling.

Fixes #245.